### PR TITLE
Fixes bug - datasets.load was not implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@ _pycache__/
 /*.egg-info
 .eggs/
 
+# Python distribution, Pip files
+.Python
+bin/
+include/
+lib/
+pip-selfcheck.json
+
 # PyPI distribution artifacts.
 build/
 dist/

--- a/tensorflow_datasets/data_loader.py
+++ b/tensorflow_datasets/data_loader.py
@@ -12,4 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from tensorflow_datasets.data_loader import load as load
+"""Data Loader functions"""
+
+def load(dataset, split="train", data_dir="~/tfdata", download=True):  # pylint: disable=unused-argument
+    """Loads datset"""
+    raise NotImplementedError


### PR DESCRIPTION
The function is still unimplemented but at least the required files are there in the library and raises a decent NotImplementedError rather than the ugly 'attribute not found'
Suggestions welcome.