### PR TITLE
typo in rock_paper_scissors.py

### DIFF
--- a/tensorflow_datasets/image/rock_paper_scissors.py
+++ b/tensorflow_datasets/image/rock_paper_scissors.py
@@ -80,7 +80,7 @@ class RockPaperScissors(tfds.core.GeneratorBasedBuilder):
     ]
 
   def _generate_examples(self, archive):
-    """Generate horses or humans images and labels given the directory path.
+    """Generate rock, paper or scissors images and labels given the directory path.
 
     Args:
       archive: object that iterates over the zip.


### PR DESCRIPTION
Hey, I was going through the code of <code>rock_paper_scissors.py</code> and I found a small typo. Please correct it. Line 83.