### PR TITLE
Fix docstring in accordance with the docs.

### DIFF
--- a/tensorflow_datasets/image/celeba.py
+++ b/tensorflow_datasets/image/celeba.py
@@ -82,9 +82,11 @@ CelebFaces Attributes Dataset (CelebA) is a large-scale face attributes dataset\
  with more than 200K celebrity images, each with 40 attribute annotations. The \
 images in this dataset cover large pose variations and background clutter. \
 CelebA has large diversities, large quantities, and rich annotations, including\
+
  - 10,177 number of identities,
  - 202,599 number of face images, and
  - 5 landmark locations, 40 binary attributes annotations per image.
+
 The dataset can be employed as the training and test sets for the following \
 computer vision tasks: face attribute recognition, face detection, and landmark\
  (or facial part) localization.


### PR DESCRIPTION
This is in regard to [this](https://github.com/tensorflow/datasets/commit/dc709442746999dda1f719d57dc4e42ffec17262) commit. The docs were updated in the commit, but they'll get overwritten when docs are regenerated. This PR fixes that by adding the changes to the docstring.