### PR TITLE
Fixed Kaggle Downloader

### DIFF
--- a/tensorflow_datasets/core/download/kaggle.py
+++ b/tensorflow_datasets/core/download/kaggle.py
@@ -101,7 +101,7 @@ class KaggleCompetitionDownloader(object):
         self._competition_name,
     ]
     output = _run_kaggle_command(command, self._competition_name)
-    return sorted([line.split(",")[0] for line in output.split("\n")[1:]])
+    return sorted([line.split(",")[0] for line in output.split("\n")[1:] if line!=""])
 
   @utils.memoized_property
   def competition_urls(self):

--- a/tensorflow_datasets/testing/test_utils.py
+++ b/tensorflow_datasets/testing/test_utils.py
@@ -401,7 +401,7 @@ def mock_kaggle_api(filenames=None, err_msg=None):
                                             tf.compat.as_bytes(err_msg))
       return tf.compat.as_bytes(
           "\n".join(["name,size,creationDate"] +
-                    ["%s,34MB,None" % fname for fname in filenames]))
+                    ["%s,34MB,None\n" % fname for fname in filenames]))
 
     return check_output
 


### PR DESCRIPTION
When cleaning output of competition_files, it's added the empty ("") line to return value and then given an error. I added the last check with if condition.

Kaggle *competition_files* *output* is 
```
name,size,creationDate
train.csv,73MB,None
test.csv,49MB,None
sample_submission.csv,235KB,2016-05-16 01:41:34
```
and then I write that code:
```python
for x, fname in enumerate(downloader.competition_files):
    print("---- ", x, fname, type(fname))
```
It's seperate like that:
```
----  0  <class 'str'>
----  1 sample_submission.csv <class 'str'>
----  2 test.csv <class 'str'>
----  3 train.csv <class 'str'>
```
And then when I am downloading:
```downloader.download_file(fname, dir_)```
It's given error. Because of zeroth variable that is empty.

I fixed this with if condition.
