### PR TITLE
Fix #237: byte strings got truncated by tf.compat.as_bytes

### DIFF
--- a/tensorflow_datasets/core/file_format_adapter.py
+++ b/tensorflow_datasets/core/file_format_adapter.py
@@ -386,8 +386,17 @@ def _item_to_tf_feature(item, key_name):
         "FeatureConnector should return a numpy array with the correct dtype "
         "instead of a Python list.".format(key_name)
     )
-  if isinstance(v, six.binary_type):
-    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[v]))
+  if isinstance(v, (six.binary_type, six.string_types)):
+    v = [tf.compat.as_bytes(v)]
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
+  elif isinstance(v, (tuple, list)) and \
+          all(isinstance(x, (six.binary_type, six.string_types)) for x in v):
+    v = [tf.compat.as_bytes(x) for x in v]
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
+  elif isinstance(v, np.ndarray) and \
+          (v.dtype.kind in ("U", "S") or v.dtype == object):  # binary or unicode
+    v = [tf.compat.as_bytes(x) for x in v.flatten()]
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
 
   v = np.array(v).flatten()  # Convert v into a 1-d array
 
@@ -395,9 +404,6 @@ def _item_to_tf_feature(item, key_name):
     return tf.train.Feature(int64_list=tf.train.Int64List(value=v))
   elif np.issubdtype(v.dtype, np.floating):
     return tf.train.Feature(float_list=tf.train.FloatList(value=v))
-  elif v.dtype.kind in ("U", "S") or v.dtype == object:  # binary or unicode
-    v = [tf.compat.as_bytes(x) for x in v]
-    return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
   else:
     raise ValueError(
         "Value received: {}.\n"

--- a/tensorflow_datasets/core/file_format_adapter.py
+++ b/tensorflow_datasets/core/file_format_adapter.py
@@ -386,6 +386,8 @@ def _item_to_tf_feature(item, key_name):
         "FeatureConnector should return a numpy array with the correct dtype "
         "instead of a Python list.".format(key_name)
     )
+  if isinstance(v, bytes) and not isinstance(v, str):
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[v]))
 
   v = np.array(v).flatten()  # Convert v into a 1-d array
 

--- a/tensorflow_datasets/core/file_format_adapter.py
+++ b/tensorflow_datasets/core/file_format_adapter.py
@@ -386,7 +386,7 @@ def _item_to_tf_feature(item, key_name):
         "FeatureConnector should return a numpy array with the correct dtype "
         "instead of a Python list.".format(key_name)
     )
-  if isinstance(v, bytes) and not isinstance(v, str):
+  if isinstance(v, six.binary_type):
     return tf.train.Feature(bytes_list=tf.train.BytesList(value=[v]))
 
   v = np.array(v).flatten()  # Convert v into a 1-d array

--- a/tensorflow_datasets/core/file_format_adapter_test.py
+++ b/tensorflow_datasets/core/file_format_adapter_test.py
@@ -153,6 +153,9 @@ class TFRecordUtilsTest(testing.TestCase):
         "c2": np.array([2.0]),
         # Empty values supported when type is defined
         "d": np.array([], dtype=np.int32),
+        # Support for byte strings
+        "e": np.zeros(2, dtype=np.uint8).tobytes(),
+        "e2": [np.zeros(2, dtype=np.uint8).tobytes()] * 2,
     })
     feature = example.features.feature
     self.assertEqual([1], list(feature["a"].int64_list.value))
@@ -162,6 +165,8 @@ class TFRecordUtilsTest(testing.TestCase):
     self.assertEqual([2.0], list(feature["c"].float_list.value))
     self.assertEqual([2.0], list(feature["c2"].float_list.value))
     self.assertEqual([], list(feature["d"].int64_list.value))
+    self.assertEqual([b"\x00\x00"], list(feature["e"].bytes_list.value))
+    self.assertEqual([b"\x00\x00", b"\x00\x00"], list(feature["e2"].bytes_list.value))
 
     with self.assertRaisesWithPredicateMatch(ValueError, "received an empty"):
       # Raise error if an undefined empty value is given


### PR DESCRIPTION
Fix for issue #237, where byte strings from a custom feature connector get truncated by `tf.compat.as_bytes`.