### PR TITLE
Reference added for "as_dataset_kwargs"

### DIFF
--- a/tensorflow_datasets/core/registered.py
+++ b/tensorflow_datasets/core/registered.py
@@ -239,6 +239,8 @@ def load(name,
     as_dataset_kwargs: `dict` (optional), keyword arguments passed to
       `tfds.core.DatasetBuilder.as_dataset`. `split` will be passed through by
       default.
+      example -> {'shuffle_files':True} 
+      NOTE: shuffle_files is by defaul False unless split == tfds.Split.TRAIN
 
   Returns:
     ds: `tf.data.Dataset`, the dataset requested, or if `split` is None, a


### PR DESCRIPTION
Added reference for the argument **as_dataset_kwargs** in ```tfds.load```

for an example -
```
train_set = tfds.load("tf_flowers", as_supervised=True, as_dataset_kwargs={'shuffle_files':True})
```