### PR TITLE
Fixed error in example code for add_dataset script

### DIFF
--- a/docs/add_dataset.md
+++ b/docs/add_dataset.md
@@ -56,7 +56,7 @@ repository and use the default template by running the following command:
 
 ```
 python tensorflow_datasets/scripts/create_new_dataset.py \
-  --name my_dataset \
+  --dataset my_dataset \
   --type image  # text, audio, translation,...
 ```
 


### PR DESCRIPTION
Updated the example code which contained a wrong flag for specifying dataset name while scaffolding a new dataset using create_new_dataset script.