### PR TITLE
Fix cats_vs_dogs dataset on Windows

### DIFF
--- a/tensorflow_datasets/image/cats_vs_dogs.py
+++ b/tensorflow_datasets/image/cats_vs_dogs.py
@@ -46,9 +46,9 @@ _DESCRIPTION = (("A large set of images of cats and dogs."
                  "There are %d corrupted images that are dropped.")
                 % _NUM_CORRUPT_IMAGES)
 
-_NAME_RE = re.compile(r"^PetImages/(Cat|Dog)/\d+\.jpg$")
+_NAME_RE = re.compile(r"^PetImages[\\/](Cat|Dog)[\\/]\d+\.jpg$")
 
-
+  
 class CatsVsDogs(tfds.core.GeneratorBasedBuilder):
   """Cats vs Dogs."""
 


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tensorflow/issues/27054

Ran into the exact same issue while going through the TF 2.0 Alpha [Transfer Learning Tutorial](https://www.tensorflow.org/alpha/tutorials/images/transfer_learning) on Windows.

The issue has been incorrectly diagnosed as being a download related issue on Windows, but in reality the download is going through successfully. The problem lies in the pre-processing of image files in `_generate_examples`  method, making use of a regular expression that only matches POSIX paths (`/` separator) but not WINDOWS paths ( `\`  separator).

This fix just updates the regex to account for either separators.

Applied the fix locally and was able to go through the tutorial on Windows.