### PR TITLE
FeaturesDict.md: use output instead of target

### DIFF
--- a/docs/api_docs/python/tfds/features/FeaturesDict.md
+++ b/docs/api_docs/python/tfds/features/FeaturesDict.md
@@ -43,7 +43,7 @@ For DatasetInfo:
 ```
 features = tfds.features.FeaturesDict({
     'input': tfds.features.Image(),
-    'target': tf.int32,
+    'output': tf.int32,
 })
 ```
 


### PR DESCRIPTION
The first example initially describes the features using the keys `input`, `target` when describing the DatasetInfo, but then (for generation time and tf.data.Dataset() time) uses `output` instead of `target`.