### PR TITLE
FeaturesDict doc: use output instead of target

### DIFF
--- a/tensorflow_datasets/core/features/feature.py
+++ b/tensorflow_datasets/core/features/feature.py
@@ -340,7 +340,7 @@ class FeaturesDict(FeatureConnector):
   ```
   features = tfds.features.FeaturesDict({
       'input': tfds.features.Image(),
-      'target': tf.int32,
+      'output': tf.int32,
   })
   ```
 


### PR DESCRIPTION
The first example initially describes the features using the keys input, target when describing the DatasetInfo, but then (for generation time and tf.data.Dataset() time) uses output instead of target.