### PR TITLE
Add Freesound Audio Tagging 2019

### DIFF
--- a/tensorflow_datasets/audio/freesound_audio_tagging_2019.py
+++ b/tensorflow_datasets/audio/freesound_audio_tagging_2019.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+
+import kaggle
+import pandas as pd
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+_TAGS = [
+    'Child_speech_and_kid_speaking', 'Cutlery_and_silverware',
+    'Marimba_and_xylophone', 'Hi-hat', 'Slam', 'Stream', 'Shatter',
+    'Mechanical_fan', 'Cupboard_open_or_close',
+    'Traffic_noise_and_roadway_noise', 'Sink_(filling_or_washing)',
+    'Female_singing', 'Raindrop', 'Zipper_(clothing)', 'Printer', 'Writing',
+    'Chewing_and_mastication', 'Bass_drum', 'Sigh', 'Trickle_and_dribble',
+    'Walk_and_footsteps', 'Church_bell', 'Buzz', 'Cricket',
+    'Computer_keyboard', 'Tick-tock', 'Male_singing',
+    'Female_speech_and_woman_speaking', 'Bass_guitar', 'Applause',
+    'Water_tap_and_faucet', 'Clapping', 'Microwave_oven',
+    'Drawer_open_or_close', 'Yell', 'Chirp_and_tweet', 'Tap', 'Cheering',
+    'Squeak', 'Screaming', 'Whispering', 'Harmonica', 'Finger_snapping',
+    'Crowd', 'Frying_(food)', 'Purr', 'Acoustic_guitar', 'Chink_and_clink',
+    'Glockenspiel', 'Run', 'Bus', 'Motorcycle', 'Hiss', 'Toilet_flush',
+    'Strum', 'Scissors', 'Male_speech_and_man_speaking', 'Gurgling',
+    'Dishes_and_pots_and_pans', 'Fart', 'Race_car_and_auto_racing',
+    'Waves_and_surf', 'Drip', 'Gong', 'Gasp',
+    'Accelerating_and_revving_and_vroom', 'Burping_and_eructation',
+    'Keys_jangling', 'Skateboard', 'Crackle', 'Electric_guitar',
+    'Bicycle_bell', 'Sneeze', 'Knock', 'Meow', 'Bark',
+    'Bathtub_(filling_or_washing)', 'Accordion', 'Fill_(with_liquid)',
+    'Car_passing_by'
+]
+
+# TODO
+_CITATION = '''\
+
+'''
+
+# TODO
+_DESCRIPTION = '''\
+The main research question addressed in this competition is how to adequately exploit a small amount of reliable, manually-labeled data, and a larger quantity of noisy web audio data in a multi-label audio tagging task with a large vocabulary setting. In addition, since the data comes from different sources, the task encourages domain adaptation approaches to deal with a potential domain mismatch.
+
+# Train set
+
+The train set is meant to be for system development. The idea is to limit the supervision provided (i.e., the manually-labeled data), thus promoting approaches to deal with label noise. The train set is composed of two subsets as follows:
+
+##Curated subset
+
+The curated subset is a small set of manually-labeled data from FSD.
+
+    Number of clips/class: 75 except in a few cases (where there are less)
+    Total number of clips: 4970
+    Avge number of labels/clip: 1.2
+    Total duration: 10.5 hours
+
+The duration of the audio clips ranges from 0.3 to 30s due to the diversity of the sound categories and the preferences of Freesound users when recording/uploading sounds. It can happen that a few of these audio clips present additional acoustic material beyond the provided ground truth label(s).
+
+## Noisy subset
+
+The noisy subset is a larger set of noisy web audio data from Flickr videos taken from the YFCC dataset.
+
+    Number of clips/class: 300
+    Total number of clips: 19815
+    Avge number of labels/clip: 1.2
+    Total duration: ~80 hours
+
+The duration of the audio clips ranges from 1s to 15s, with the vast majority lasting 15s.
+
+Considering the numbers above, per-class data distribution available for training is, for most of the classes, 300 clips from the noisy subset and 75 clips from the curated subset, which means 80% noisy - 20% curated at the clip level (not at the audio duration level, considering the variable-length clips).
+'''
+
+_URLS = [
+    'http://dcase.community/challenge2019/task-audio-tagging',
+    'https://www.kaggle.com/c/freesound-audio-tagging-2019/',
+]
+
+
+class FreesoundAudioTagging2019Config(tfds.core.BuilderConfig):
+    def __init__(self, concatenate_sources=False, **kwargs):
+        self.concatenate_sources = concatenate_sources
+        super(FreesoundAudioTagging2019Config, self).__init__(**kwargs)
+
+
+class FreesoundAudioTagging2019(tfds.core.GeneratorBasedBuilder):
+
+    # TODO Is there an official semver version for the dataset?
+    VERSION = tfds.core.Version('1.0.0')
+
+    def _info(self):
+        audio = tfds.features.Text()
+        tags = tfds.features.FeaturesDict({name: tf.bool for name in _TAGS})
+        dataset_info = tfds.core.DatasetInfo(
+            builder=self,
+            description=_DESCRIPTION,
+            features=tfds.features.FeaturesDict({
+                'audio': audio,
+                'tags': tags
+            }),
+            supervised_keys=('audio', 'tags'),
+            urls=_URLS,
+            citation=_CITATION,
+        )
+        return dataset_info
+
+    def _split_generators(self, dl_manager):
+        download_dir = Path(dl_manager._download_dir)
+
+        csvs = {
+            tfds.Split.TRAIN: download_dir / 'train_noisy.csv',
+            tfds.Split.VALIDATION: download_dir / 'train_curated.csv',
+            tfds.Split.TEST: download_dir / 'sample_submission.csv',
+        }
+
+        zips = {
+            tfds.Split.TRAIN: download_dir / 'train_noisy.zip',
+            tfds.Split.VALIDATION: download_dir / 'train_curated.zip',
+            tfds.Split.TEST: download_dir / 'test.zip',
+        }
+
+        kaggle.api.authenticate()
+        for resource in list(csvs.values()) + list(zips.values()):
+            if not resource.is_file():
+                kaggle.api.competition_download_file(
+                    competition='freesound-audio-tagging-2019',
+                    file_name=resource.name,
+                    path=download_dir,
+                    quiet=False,
+                )
+
+        zips = {k: v.as_posix() for k, v in zips.items()}
+        dirs = dl_manager.extract(zips)
+
+        splits = [tfds.Split.TRAIN, tfds.Split.VALIDATION, tfds.Split.TEST]
+        split_generators = [
+            tfds.core.SplitGenerator(
+                name=tfds.Split,
+                gen_kwargs={
+                    'csv_path': csvs[tfds.Split],
+                    'data_path': dirs[tfds.Split]
+                },
+            ) for tfds.Split in splits
+        ]
+        return split_generators
+
+    def _generate_examples(self, csv_path, data_path):
+        data_path = Path(data_path)
+        df = pd.read_csv(csv_path)
+        if 'labels' in df.columns:
+            df = df.join(df.labels.str.get_dummies(','))
+        for i, row in df.iterrows():
+            audio = (data_path / row['fname']).as_posix()
+            tags = {tag: row[tag] for tag in _TAGS}
+            yield {'audio': audio, 'tags': tags}

--- a/tensorflow_datasets/audio/freesound_audio_tagging_2019_test.py
+++ b/tensorflow_datasets/audio/freesound_audio_tagging_2019_test.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+# Copyright 2019 The TensorFlow Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Freesound Audio Tagging 2019 dataset module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from multiprocessing import cpu_count
+
+import tensorflow as tf
+
+from tensorflow_datasets import testing
+from tensorflow_datasets.audio import freesound_audio_tagging_2019
+
+
+def test_spectrogram():
+    def preprocess(row):
+        audio_path = row['audio']
+        blob = tf.io.read_file(audio_path)
+
+        waveform = tf.audio.decode_wav(blob, 1, 3.0 * 44100)[0]
+
+        x = tf.transpose(waveform)
+        x = tf.signal.stft(x, 1024, 512)
+        x = tf.transpose(x, (1, 2, 0))
+        spectrogram = tf.abs(x)
+
+        tags = row['tags']
+        tags = tf.stack(list(tags.values()))
+
+        return spectrogram, tags
+
+    dataset = tfds.load(
+        name='freesound_audio_tagging2019',
+        split=tfds.Split.TRAIN,
+    )
+
+    batch_size = 32
+    dataset = dataset.map(preprocess, cpu_count()).cache().shuffle(
+        256).repeat().batch(batch_size).prefetch(1)
+
+    for spectrogram, tags in dataset:
+        print(spectrogram.shape, tags.shape)
+        assert spectrogram.shape == [batch_size, 257, 513, 1]
+        assert tags.shape == [batch_size, 80]
+        break
+
+
+# TODO
+class FreesoundAudioTagging2019FullTest(testing.DatasetBuilderTestCase):
+    DATASET_CLASS = freesound_audio_tagging2019.FreesoundAudioTagging2019
+    BUILDER_CONFIG_NAMES_TO_TEST = ["full-16000hz"]
+    SPLITS = {
+        "train": 2,
+        "test": 1,
+    }
+    DL_EXTRACT_RESULT = ".."
+
+
+if __name__ == "__main__":
+    testing.test_main()


### PR DESCRIPTION
I'd love to see tfds include [the DCASE task that's on Kaggle currently](https://www.kaggle.com/c/freesound-audio-tagging-2019/), but I didn't find any issues or pull requests for adding it so here's my attempt. I'm opening a pull request early so we can pool efforts, in case anyone else would like to make this happen! :koala: 

I still have some reading of the contribution guidelines to do (on it!). Adding `pandas`, and `kaggle` for example, code formatting, unit test framework used by tfds, and so on are on my TODO.

## Loading audio?
`tfds.features.Audio` is really slow (it seems to do single threaded calls to pydub regardless of minibatch size), and I noticed that @adarob's Groove addition just now didn't go via the existing feature connector at all. Is stuff intended to move around? What encoding is preferred for audio datasets? 

Currently this pull request just lets the user consume the file path to the WAV file manually, by returning a `tf.string` with the path to audio file, then a subsequent `tf.io.read_file` and `tf.audio.decode_wav` call can be parallelised in `tf.data.Dataset.map`.

## How to encode multi-label datasets?
Throughout tfds there doesn't seem to be a strong convention for how to encode multi-label datasets, and there doesn't seem to be a feature connector for binary indicator variables yet. I copied the encoding used by the NSynth dataset, where a nested `FeaturesDict` simply contains individual `tf.bool`:s per label, but then it's up to the user to concatenate them which can be bug prone.

## Splitting the dataset
Since the competition is interested in training on noisy labels, and evaluating on curated labels, I think we should default to splitting the dataset in exactly that manner despite the fact that you'd probably rank higher on the Kaggle leaderboard by training on some of the curated data (as that's the same source that's used for the hidden test set).

Another discussion point is how to treat the fact that the test dataset doesn't have any labels. Currently, I'm just returning whatever [0.0,1.0] scores are set in the example_submission.csv provided by the competition.