### PR TITLE
Multi-names support for ClassLabel.

### DIFF
--- a/tensorflow_datasets/core/features/class_label_feature.py
+++ b/tensorflow_datasets/core/features/class_label_feature.py
@@ -8,7 +8,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distribsuted on an "AS IS" BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/tensorflow_datasets/core/features/class_label_feature.py
+++ b/tensorflow_datasets/core/features/class_label_feature.py
@@ -8,13 +8,14 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distribsuted on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
 """ClassLabel feature."""
 
+import json
 import os
 import six
 import tensorflow as tf
@@ -33,7 +34,7 @@ class ClassLabel(feature.Tensor):
     arguments:
 
      * `num_classes`: create 0 to (num_classes-1) labels
-     * `names`: a list of label strings
+     * `names`: a list of label strings or a list of label/mapping dicts
      * `names_file`: a file containing the list of labels.
 
     Note: On python2, the strings are encoded as utf-8.
@@ -41,6 +42,8 @@ class ClassLabel(feature.Tensor):
     Args:
       num_classes: `int`, number of classes. All labels must be < num_classes.
       names: `list<str>`, string names for the integer classes. The
+        order in which the names are provided is kept.
+             `list<dict>`, dict features for the integer classes. The
         order in which the names are provided is kept.
       names_file: `str`, path to a file with names for the integer
         classes, one per line.
@@ -50,6 +53,7 @@ class ClassLabel(feature.Tensor):
     self._num_classes = None
     self._str2int = None
     self._int2str = None
+    self._is_multilabel = False
 
     # The label is explicitly set as undefined (no label defined)
     if not sum(bool(a) for a in (num_classes, names, names_file)):
@@ -70,13 +74,20 @@ class ClassLabel(feature.Tensor):
 
   @property
   def names(self):
+    if self._is_multilabel:
+      return list(self._int2str)
     if not self._int2str:
       return [tf.compat.as_text(str(i)) for i in range(self._num_classes)]
     return list(self._int2str)
 
   @names.setter
   def names(self, new_names):
-    int2str = [tf.compat.as_text(name) for name in new_names]
+    if type(new_names) == list and type(new_names[0]) == dict:
+      self._is_multilabel = True
+      self._num_classes = len(new_names)
+      int2str = [name for name in new_names]
+    else:
+      int2str = [tf.compat.as_text(name) for name in new_names]
     # Names can only be defined once
     if self._int2str is not None and self._int2str != int2str:
       raise ValueError(
@@ -85,21 +96,30 @@ class ClassLabel(feature.Tensor):
 
     # Set-up [new] names
     self._int2str = int2str
-    self._str2int = {name: i for i, name in enumerate(self._int2str)}
+    # str2int only for string labels not for dict labels for now
+    if not self._is_multilabel:
+      self._str2int = {name: i for i, name in enumerate(self._int2str)}
 
-    # If num_classes has been defined, ensure that num_classes and names match
-    num_classes = len(self._str2int)
-    if self._num_classes is None:
-      self._num_classes = num_classes
-    elif self._num_classes != num_classes:
-      raise ValueError(
-          "ClassLabel number of names do not match the defined num_classes. "
-          "Got {} names VS {} num_classes".format(
-              num_classes, self._num_classes)
-      )
+      # If num_classes has been defined, ensure that num_classes and names match
+      num_classes = len(self._str2int)
+      if self._num_classes is None:
+        self._num_classes = num_classes
+      elif self._num_classes != num_classes:
+        raise ValueError(
+            "ClassLabel number of names do not match the defined num_classes. "
+            "Got {} names VS {} num_classes".format(
+                num_classes, self._num_classes)
+        )
 
   def str2int(self, str_value):
-    """Conversion class name string => integer."""
+    """Conversion class name string/dict => integer."""
+    # Linear Search for dict values to find the integer class
+    if self._is_multilabel:
+      for i in range(len(self._int2str)):
+        if self._int2str[i] == str_value:
+          return i
+      else:
+        raise ValueError("Invalid dict class label %s" % str_value)
     str_value = tf.compat.as_text(str_value)
     if self._str2int:
       return self._str2int[str_value]
@@ -148,26 +168,36 @@ class ClassLabel(feature.Tensor):
   def save_metadata(self, data_dir, feature_name=None):
     """See base class for details."""
     # Save names if defined
-    if self._str2int is not None:
+    if not self._is_multilabel and self._str2int is not None:
       names_filepath = _get_names_filepath(data_dir, feature_name)
       _write_names_to_file(names_filepath, self.names)
+    # For dict feature
+    if self._is_multilabel:
+      names_filepath = _get_names_filepath(data_dir, feature_name, self._is_multilabel)
+      _write_names_to_file(names_filepath, self.names, self._is_multilabel)
 
   def load_metadata(self, data_dir, feature_name=None):
     """See base class for details."""
     # Restore names if defined
-    names_filepath = _get_names_filepath(data_dir, feature_name)
+    names_filepath = _get_names_filepath(data_dir, feature_name, self._is_multilabel)
     if tf.io.gfile.exists(names_filepath):
-      self.names = _load_names_from_file(names_filepath)
+      self.names = _load_names_from_file(names_filepath, self._is_multilabel)
 
   def _additional_repr_info(self):
     return {"num_classes": self.num_classes}
 
 
-def _get_names_filepath(data_dir, feature_name):
+def _get_names_filepath(data_dir, feature_name, is_multilabel=False):
+  if is_multilabel:
+    return os.path.join(data_dir, "{}.labels.json".format(feature_name))
   return os.path.join(data_dir, "{}.labels.txt".format(feature_name))
 
 
-def _load_names_from_file(names_filepath):
+def _load_names_from_file(names_filepath, is_multilabel=False):
+  if is_multilabel:
+    with open(names_filepath, "r") as f:
+      names = json.load(f)
+    return names  
   with tf.io.gfile.GFile(names_filepath, "r") as f:
     return [
         name.strip()
@@ -176,6 +206,10 @@ def _load_names_from_file(names_filepath):
     ]
 
 
-def _write_names_to_file(names_filepath, names):
-  with tf.io.gfile.GFile(names_filepath, "w") as f:
-    f.write("\n".join(names) + "\n")
+def _write_names_to_file(names_filepath, names, is_multilabel=False):
+  if is_multilabel:
+    with open(names_filepath, "w") as f:
+      json.dump(names, f)
+  else:
+    with tf.io.gfile.GFile(names_filepath, "w") as f:
+      f.write("\n".join(names) + "\n")

--- a/tensorflow_datasets/core/features/class_label_feature_test.py
+++ b/tensorflow_datasets/core/features/class_label_feature_test.py
@@ -109,6 +109,26 @@ class ClassLabelFeatureTest(testing.FeatureExpectationsTestCase):
     self.assertEqual(labels.int2str(0), 'label3')
     self.assertEqual(labels.int2str(1), 'label1')
     self.assertEqual(labels.int2str(2), 'label2')
+    
+  def test_dict_classes(self):
+    labels = features.ClassLabel(names=[
+        {'wordnet': 'n02119789', 'class_id': 1, 'name': 'kit_fox'},
+        {'wordnet': 'n02100735', 'class_id': 2, 'name': 'English_setter'},
+        {'wordnet': 'n02110185', 'class_id': 3, 'name': 'Siberian_husky'},
+    ])
+    self.assertEqual(3, labels.num_classes)
+    self.assertEqual(labels.names, [
+        {'wordnet': 'n02119789', 'class_id': 1, 'name': 'kit_fox'},
+        {'wordnet': 'n02100735', 'class_id': 2, 'name': 'English_setter'},
+        {'wordnet': 'n02110185', 'class_id': 3, 'name': 'Siberian_husky'},
+    ])
+
+    self.assertEqual(labels.str2int({'wordnet': 'n02119789', 'class_id': 1, 'name': 'kit_fox'}), 0)
+    self.assertEqual(labels.str2int({'wordnet': 'n02100735', 'class_id': 2, 'name': 'English_setter'}), 1)
+    self.assertEqual(labels.str2int({'wordnet': 'n02110185', 'class_id': 3, 'name': 'Siberian_husky'}), 2)
+    self.assertEqual(labels.int2str(0), {'wordnet': 'n02119789', 'class_id': 1, 'name': 'kit_fox'})
+    self.assertEqual(labels.int2str(1), {'wordnet': 'n02100735', 'class_id': 2, 'name': 'English_setter'})
+    self.assertEqual(labels.int2str(2), {'wordnet': 'n02110185', 'class_id': 3, 'name': 'Siberian_husky'})
 
   def test_save_load(self):
     labels1 = features.ClassLabel(names=['label3', 'label1', 'label2'])
@@ -128,6 +148,28 @@ class ClassLabelFeatureTest(testing.FeatureExpectationsTestCase):
         'label3',
         'label1',
         'label2',
+    ])
+    
+  def test_save_load_dict(self):
+    labels1 = features.ClassLabel(names=[
+        {'wordnet': 'n02119789', 'class_id': 1, 'name': 'kit_fox'},
+        {'wordnet': 'n02100735', 'class_id': 2, 'name': 'English_setter'},
+        {'wordnet': 'n02110185', 'class_id': 3, 'name': 'Siberian_husky'},
+    ])
+    labels2 = features.ClassLabel(num_classes=None)
+
+    with testing.tmp_dir(self.get_temp_dir()) as tmp_dir:
+      labels1.save_metadata(tmp_dir, 'test-labels-dict')
+      # Setting labels2._is_multilabel = True because by default it is False and cannot load 'json' file
+      labels2._is_multilabel = True
+      labels2.load_metadata(tmp_dir, 'test-labels-dict')
+
+    # labels2 should have been copied from label1
+    self.assertEqual(3, labels2.num_classes)
+    self.assertEqual(labels2.names, [
+        {'wordnet': 'n02119789', 'class_id': 1, 'name': 'kit_fox'},
+        {'wordnet': 'n02100735', 'class_id': 2, 'name': 'English_setter'},
+        {'wordnet': 'n02110185', 'class_id': 3, 'name': 'Siberian_husky'},
     ])
 
   def test_names(self):


### PR DESCRIPTION
Initial commit for `Multi-names support for ClassLabel`.
The main idea here is to expose the multiple ways of labelling as seen in `imagenet`, `cifar100`, etc..

Please do suggest changes or better ideas for the improvement.
 