### PR TITLE
Improve usability of `batch_size` in `as_dataset`.

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -298,7 +298,7 @@ class DatasetBuilder(object):
   @api_utils.disallow_positional_args
   def as_dataset(self,
                  split=None,
-                 batch_size=1,
+                 batch_size=None,
                  shuffle_files=None,
                  as_supervised=False):
     """Constructs a `tf.data.Dataset`.
@@ -366,7 +366,7 @@ class DatasetBuilder(object):
       batch_size = self.info.splits.total_num_examples or sys.maxsize
 
     dataset = self._as_dataset(split=split, shuffle_files=shuffle_files)
-    if batch_size > 1:
+    if batch_size:
       # Use padded_batch so that features with unknown shape are supported.
       padded_shapes = self.info.features.shape
       dataset = dataset.padded_batch(batch_size, padded_shapes)

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import abc
 import functools
+import itertools
 import os
 import sys
 
@@ -163,6 +164,9 @@ class DatasetBuilder(object):
         `builder_config`s will have their own subdirectories and versions.
       version: `str`. Optional version at which to load the dataset. An error is
         raised if specified version cannot be satisfied. Eg: '1.2.3', '1.2.*'.
+        The special value "experimental_latest" will use the highest version,
+        even if not default. This is not recommended unless you know what you
+        are doing, as the version could be broken.
     """
     self._builder_config = self._create_builder_config(config)
     # Extract code version (VERSION or config)
@@ -193,6 +197,8 @@ class DatasetBuilder(object):
         utils.Version(v) if isinstance(v, six.string_types) else v
         for v in [canonical_version] + supported_versions
     ]
+    if requested_version == "experimental_latest":
+      return max(versions)
     for version in versions:
       if requested_version is None or version.match(requested_version):
         return version
@@ -201,6 +207,10 @@ class DatasetBuilder(object):
     msg = "Dataset {} cannot be loaded at version {}, only: {}.".format(
         self.name, requested_version, ", ".join(available_versions))
     raise AssertionError(msg)
+
+  @property
+  def version(self):
+    return self._version
 
   @property
   def data_dir(self):
@@ -636,25 +646,6 @@ class FileAdapterBuilder(DatasetBuilder):
     fraction of the `TRAIN` data for evaluation as you iterate on your model
     so as not to overfit to the `TEST` data.
 
-    You can use a single generator shared between splits by providing list
-    instead of values for `tfds.SplitGenerator` (this is the case if the
-    underlying dataset does not have pre-defined data splits):
-
-      return [tfds.SplitGenerator(
-          name=[tfds.Split.TRAIN, tfds.Split.VALIDATION],
-          num_shards=[10, 3],
-      )]
-
-    This will call `_generate_examples()` once but will automatically distribute
-    the examples between train and validation set.
-    The proportion of the examples that will end up in each split is defined
-    by the relative number of shards each `ShardFiles` object specifies. In
-    the previous case, the train split would contains 10/13 of the examples,
-    while the validation split would contain 3/13.
-
-    Warning: Each shard shouldn't be bigger than 4GiB as shards are loaded
-    entirely in memory during shuffling
-
     For downloads and extractions, use the given `download_manager`.
     Note that the `DownloadManager` caches downloads, so it is fine to have each
     generator attempt to download the source data.
@@ -689,16 +680,15 @@ class FileAdapterBuilder(DatasetBuilder):
     split_dict = splits_lib.SplitDict()
     for split_generator in self._split_generators(dl_manager):
       # Keep track of all split_info
-      for s in split_generator.split_info_list:
-        if splits_lib.Split.ALL == s.name:
-          raise ValueError(
-              "tfds.Split.ALL is a special split keyword corresponding to the "
-              "union of all splits, so cannot be used as key in "
-              "._split_generator()."
-          )
+      if splits_lib.Split.ALL == split_generator.split_info.name:
+        raise ValueError(
+            "tfds.Split.ALL is a special split keyword corresponding to the "
+            "union of all splits, so cannot be used as key in "
+            "._split_generator()."
+        )
 
-        logging.info("Generating split %s", s.name)
-        split_dict.add(s)
+      logging.info("Generating split %s", split_generator.split_info.name)
+      split_dict.add(split_generator.split_info)
 
       # Prepare split will record examples associated to the split
       self._prepare_split(split_generator, **prepare_split_kwargs)
@@ -737,8 +727,7 @@ class FileAdapterBuilder(DatasetBuilder):
 
       # Compute filenames from the given split
       filepaths = list(sorted(self._build_split_filenames(
-          split_info_list=[sliced_split_info.split_info],
-      )))
+          sliced_split_info.split_info)))
 
       # Compute the offsets
       if sliced_split_info.split_info.num_examples:
@@ -763,31 +752,27 @@ class FileAdapterBuilder(DatasetBuilder):
         })
     return instruction_dicts
 
-  def _build_split_filenames(self, split_info_list):
+  def _build_split_filenames(self, split_info):
     """Construct the split filenames associated with the split info.
 
     The filenames correspond to the pre-processed datasets files present in
     the root directory of the dataset.
 
     Args:
-      split_info_list: (list[SplitInfo]) List of split from which generate the
-        filenames
+      split_info: (SplitInfo) needed split.
 
     Returns:
       filenames: (list[str]) The list of filenames path corresponding to the
         split info object
     """
 
-    filenames = []
-    for split_info in split_info_list:
-      filenames.extend(naming.filepaths_for_dataset_split(
-          dataset_name=self.name,
-          split=split_info.name,
-          num_shards=split_info.num_shards,
-          data_dir=self._data_dir,
-          filetype_suffix=self._file_format_adapter.filetype_suffix,
-      ))
-    return filenames
+    return naming.filepaths_for_dataset_split(
+        dataset_name=self.name,
+        split=split_info.name,
+        num_shards=split_info.num_shards,
+        data_dir=self._data_dir,
+        filetype_suffix=self._file_format_adapter.filetype_suffix,
+        )
 
 
 class GeneratorBasedBuilder(FileAdapterBuilder):
@@ -832,34 +817,13 @@ class GeneratorBasedBuilder(FileAdapterBuilder):
     )
 
   def _prepare_split(self, split_generator, max_examples_per_split):
-
+    generator = self._generate_examples(**split_generator.gen_kwargs)
     if max_examples_per_split is not None:
-      logging.warn("Splits capped at %s examples max.",
-                   max_examples_per_split)
-
-    # Generate the filenames and write the example on disk
-    def make_generator_fn(**kwargs):
-      """Returns generator_fn bound to **kwargs."""
-
-      def generator_fn():
-        for i, ex in enumerate(self._generate_examples(**kwargs)):
-          # Use the DatasetInfo FeaturesDict to encode the example. This allows
-          # the user's function to simply yield raw examples from the source
-          # data, which makes reusing it easier.
-          if (max_examples_per_split and
-              i >= max_examples_per_split):
-            break
-          yield self.info.features.encode_example(ex)
-
-      return generator_fn
-
-    output_files = self._build_split_filenames(
-        split_info_list=split_generator.split_info_list,
-    )
-    self._file_format_adapter.write_from_generator(
-        make_generator_fn(**split_generator.gen_kwargs),
-        output_files,
-    )
+      logging.warn("Splits capped at %s examples max.", max_examples_per_split)
+      generator = itertools.islice(generator, max_examples_per_split)
+    generator = (self.info.features.encode_example(ex) for ex in generator)
+    output_files = self._build_split_filenames(split_generator.split_info)
+    self._file_format_adapter.write_from_generator(generator, output_files)
 
 
 class BeamBasedBuilder(FileAdapterBuilder):
@@ -943,14 +907,7 @@ class BeamBasedBuilder(FileAdapterBuilder):
     if not tf.io.gfile.exists(self._data_dir):
       tf.io.gfile.makedirs(self._data_dir)
 
-    if len(split_generator.split_info_list) > 1:
-      # Could support Shared-split PCollection, either with same behavior as
-      # GeneratorBasedBuilder, or by having each value be a tuple
-      # ('split_name', example_value) ? Or should we return three branched
-      # PCollections ? Should ask for user feedback
-      raise NotImplementedError("Shared-split PCollections not supported yet.")
-
-    split_info = split_generator.split_info_list[0]
+    split_info = split_generator.split_info
     output_prefix = naming.filename_prefix_for_split(
         self.name, split_info.name)
     output_prefix = os.path.join(self._data_dir, output_prefix)

--- a/tensorflow_datasets/core/dataset_builder_test.py
+++ b/tensorflow_datasets/core/dataset_builder_test.py
@@ -69,9 +69,15 @@ class DummyDatasetWithConfigs(dataset_builder.GeneratorBasedBuilder):
     del dl_manager
     return [
         splits_lib.SplitGenerator(
-            name=[splits_lib.Split.TRAIN, splits_lib.Split.TEST],
-            num_shards=[2, 1],
-        )
+            name=splits_lib.Split.TRAIN,
+            num_shards=2,
+            gen_kwargs={"range_": range(20)},
+        ),
+        splits_lib.SplitGenerator(
+            name=splits_lib.Split.TEST,
+            num_shards=1,
+            gen_kwargs={"range_": range(20, 30)},
+        ),
     ]
 
   def _info(self):
@@ -82,8 +88,8 @@ class DummyDatasetWithConfigs(dataset_builder.GeneratorBasedBuilder):
         supervised_keys=("x", "x"),
     )
 
-  def _generate_examples(self):
-    for i in range(30):
+  def _generate_examples(self, range_):
+    for i in range_:
       if self.builder_config:
         i += self.builder_config.increment
       yield {"x": i}
@@ -101,44 +107,6 @@ class InvalidSplitDataset(DummyDatasetWithConfigs):
 
 
 class DatasetBuilderTest(testing.TestCase):
-
-  @testing.run_in_graph_and_eager_modes()
-  def test_shared_generator(self):
-    with testing.tmp_dir(self.get_temp_dir()) as tmp_dir:
-      builder = DummyDatasetSharedGenerator(data_dir=tmp_dir)
-      builder.download_and_prepare()
-
-      written_filepaths = [
-          os.path.join(builder._data_dir, fname)
-          for fname in tf.io.gfile.listdir(builder._data_dir)
-      ]
-      # The data_dir contains the cached directory by default
-      expected_filepaths = builder._build_split_filenames(
-          split_info_list=builder.info.splits.values())
-      expected_filepaths.append(
-          os.path.join(builder._data_dir, "dataset_info.json"))
-      self.assertEqual(sorted(expected_filepaths), sorted(written_filepaths))
-
-      splits_list = [
-          splits_lib.Split.TRAIN, splits_lib.Split.TEST
-      ]
-      train_data, test_data = [
-          [el["x"] for el in
-           dataset_utils.as_numpy(builder.as_dataset(split=split))]
-          for split in splits_list
-      ]
-
-      self.assertEqual(20, len(train_data))
-      self.assertEqual(10, len(test_data))
-      self.assertEqual(list(range(30)), sorted(train_data + test_data))
-
-      # Builder's info should also have the above information.
-      self.assertTrue(builder.info.initialized)
-      self.assertEqual(20,
-                       builder.info.splits[splits_lib.Split.TRAIN].num_examples)
-      self.assertEqual(10,
-                       builder.info.splits[splits_lib.Split.TEST].num_examples)
-      self.assertEqual(30, builder.info.splits.total_num_examples)
 
   @testing.run_in_graph_and_eager_modes()
   def test_load(self):
@@ -164,7 +132,7 @@ class DatasetBuilderTest(testing.TestCase):
 
       # Ensure determinism. If this test fail, this mean that numpy random
       # module isn't always determinist (maybe between version, architecture,
-      # ...), and so our datasets aren't guarantee either
+      # ...), and so our datasets aren't guaranteed either.
       l = list(range(20))
       np.random.RandomState(42).shuffle(l)
       self.assertEqual(l, [
@@ -175,8 +143,8 @@ class DatasetBuilderTest(testing.TestCase):
       # deterministically generated.
       self.assertEqual(
           [e["x"] for e in ds_values],
-          [24, 1, 3, 4, 15, 25, 0, 16, 21, 10, 6, 13, 27, 22, 12, 28, 9, 19,
-           18, 7],
+          [16, 1, 2, 3, 10, 17, 0, 11, 14, 7, 4, 9, 18, 15, 8, 19, 6, 13, 12,
+           5],
       )
 
   @testing.run_in_graph_and_eager_modes()
@@ -272,6 +240,12 @@ class DatasetBuilderTest(testing.TestCase):
 
   def test_with_supported_version(self):
     DummyDatasetWithConfigs(config="plus1", version="0.0.1")
+
+  def test_latest_experimental_version(self):
+    builder1 = DummyDatasetSharedGenerator()
+    self.assertEqual(str(builder1._version), "1.0.0")
+    builder2 = DummyDatasetSharedGenerator(version="experimental_latest")
+    self.assertEqual(str(builder2._version), "2.0.0")
 
   def test_with_unsupported_version(self):
     expected = "Dataset dummy_dataset_with_configs cannot be loaded at version"
@@ -449,6 +423,16 @@ class DatasetBuilderReadTest(testing.TestCase):
     self.assertEqual(10, x2.shape[0])
     self.assertEqual(10, x3.shape[0])
     self.assertEqual(sum(range(30)), int(x1.sum() + x2.sum() + x3.sum()))
+    
+    # By default batch_size is None and won't add a batch dimension
+    ds = self.builder.as_dataset(split=splits_lib.Split.TRAIN)
+    self.assertEqual(0, len(ds.output_shapes["x"]))
+    # Setting batch_size=1 will add an extra batch dimension
+    ds = self.builder.as_dataset(split=splits_lib.Split.TRAIN, batch_size=1)
+    self.assertEqual(1, len(ds.output_shapes["x"]))
+    # Setting batch_size=2 will add an extra batch dimension
+    ds = self.builder.as_dataset(split=splits_lib.Split.TRAIN, batch_size=2)
+    self.assertEqual(1, len(ds.output_shapes["x"]))
 
   @testing.run_in_graph_and_eager_modes()
   def test_supervised_keys(self):

--- a/tensorflow_datasets/core/registered.py
+++ b/tensorflow_datasets/core/registered.py
@@ -176,7 +176,7 @@ def builder(name, **builder_init_kwargs):
 def load(name,
          split=None,
          data_dir=None,
-         batch_size=1,
+         batch_size=None,
          download=True,
          as_supervised=False,
          with_info=False,

--- a/tensorflow_datasets/core/registered_test.py
+++ b/tensorflow_datasets/core/registered_test.py
@@ -120,7 +120,7 @@ class RegisteredTest(testing.TestCase):
     self.assertFalse(builder.download_called)
     self.assertEqual(splits.Split.TEST,
                      builder.as_dataset_kwargs.pop("split"))
-    self.assertEqual(1, builder.as_dataset_kwargs.pop("batch_size"))
+    self.assertEqual(None, builder.as_dataset_kwargs.pop("batch_size"))
     self.assertFalse(builder.as_dataset_kwargs.pop("as_supervised"))
     self.assertEqual(builder.as_dataset_kwargs, as_dataset_kwargs)
     self.assertEqual(dict(data_dir=data_dir, k1=1), builder.kwargs)
@@ -130,6 +130,22 @@ class RegisteredTest(testing.TestCase):
         download=True, as_dataset_kwargs=as_dataset_kwargs)
     self.assertTrue(builder.as_dataset_called)
     self.assertTrue(builder.download_called)
+    
+    # Tests for different batch_size
+    # By default batch_size=None
+    builder = registered.load(
+        name=name, split=splits.Split.TEST, data_dir=data_dir)
+    self.assertEqual(None, builder.as_dataset_kwargs.pop("batch_size"))
+    # Setting batch_size=1
+    builder = registered.load(
+        name=name, split=splits.Split.TEST, data_dir=data_dir,
+        batch_size=1)
+    self.assertEqual(1, builder.as_dataset_kwargs.pop("batch_size"))
+    # Setting batch_size=2
+    builder = registered.load(
+        name=name, split=splits.Split.TEST, data_dir=data_dir,
+        batch_size=2)
+    self.assertEqual(2, builder.as_dataset_kwargs.pop("batch_size"))
 
   def test_load_all_splits(self):
     name = "empty_dataset_builder"


### PR DESCRIPTION
Currently, in the `as_dataset` function, `batch_size=1` won't add a batch dimension while `batch_size=2` will. This is inconsistent for the users as passing the `batch_size` as flag will modify the tensors shape.
Sol: Have `batch_size=None` (default) do not return batch_dimension while `batch_size=1` does.

```
>>> import tensorflow_datasets as tfds
>>> 
>>> ds=tfds.load('mnist', split='train', batch_size=None)
>>> ds
<DatasetV1Adapter shapes: {image: (28, 28, 1), label: ()}, types: {image: tf.uint8, label: tf.int64}>
>>> 
>>> ds=tfds.load('mnist', split='train', batch_size=1)
>>> ds
<DatasetV1Adapter shapes: {image: (?, 28, 28, 1), label: (?,)}, types: {image: tf.uint8, label: tf.int64}>
>>> 
>>> ds=tfds.load('mnist', split='train', batch_size=2)
>>> ds
<DatasetV1Adapter shapes: {image: (?, 28, 28, 1), label: (?,)}, types: {image: tf.uint8, label: tf.int64}>
```