### PR TITLE
Added Support for CA Files in Downloader #275

### DIFF
--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -186,8 +186,7 @@ class _Downloader(object):
       if proxies['ftp']:
         proxy = urllib.request.ProxyHandler({'ftp': proxies['ftp']})
         opener = urllib.request.build_opener(proxy)
-        urllib.request.install_opener(
-            opener)   # pylint: disable=too-many-function-args
+        urllib.request.install_opener(opener)   # pylint: disable=too-many-function-args
       request = urllib.request.Request(url)
 
       if CA_VERIFY['urllib'] is None:     # disable ssl context check for python version <= 2.7.8

--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -150,13 +150,25 @@ class _Downloader(object):
         'ftp': os.environ.get('TFDS_FTP_PROXY', None)
     }
     CA_BUNDLE = os.environ.get('TFDS_CA_BUNDLE', None)
+    
+    if not hasattr(ssl, "_create_unverified_context"):
+      # For python Version <= 2.7.16
+      def py2_fn():
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+      ssl.__dict__["_create_unverified_context"] = py2_fn
+
     if CA_BUNDLE:
       CA_BUNDLE = extract_zipped_paths(CA_BUNDLE)
+    
     CA_VERIFY = {
         'urllib': ssl._create_unverified_context() if CA_BUNDLE is None
         else ssl.create_default_context(capath=CA_BUNDLE),
         'requests': False if CA_BUNDLE is None else CA_BUNDLE
     }
+    
     if kaggle.KaggleFile.is_kaggle_url(url):
       if proxies['http']:
         os.environ['KAGGLE_PROXY'] = proxies['http']

--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -149,8 +149,11 @@ class _Downloader(object):
         'https': os.environ.get('TFDS_HTTPS_PROXY', None),
         'ftp': os.environ.get('TFDS_FTP_PROXY', None)
     }
-    CA_BUNDLE = os.environ.get('TFDS_CA_BUNDLE', None)
-
+    CA_BUNDLE = os.environ.get(
+        'TFDS_CA_BUNDLE',
+        None) or os.environ.get(
+        'REQUESTS_CA_BUNDLE',
+        None)
     if CA_BUNDLE:
       CA_BUNDLE = extract_zipped_paths(CA_BUNDLE)
     if not hasattr(ssl, '_create_unverified_context'):

--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -153,8 +153,8 @@ class _Downloader(object):
     if CA_BUNDLE:
       CA_BUNDLE = extract_zipped_paths(CA_BUNDLE)
     CA_VERIFY = {
-        'urllib':  ssl._create_unverified_context() if CA_BUNDLE is None 
-                   else ssl.create_default_context(capath=CA_BUNDLE),
+        'urllib': ssl._create_unverified_context() if CA_BUNDLE is None
+        else ssl.create_default_context(capath=CA_BUNDLE),
         'requests': False if CA_BUNDLE is None else CA_BUNDLE
     }
     if kaggle.KaggleFile.is_kaggle_url(url):

--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -159,11 +159,9 @@ class _Downloader(object):
         'https': os.environ.get('TFDS_HTTPS_PROXY', None),
         'ftp': os.environ.get('TFDS_FTP_PROXY', None)
     }
-    ca_bundle = os.environ.get(
-        'TFDS_CA_BUNDLE',
-        None) or os.environ.get(
-        'REQUESTS_CA_BUNDLE',
-        None)
+    ca_bundle = os.environ.get('TFDS_CA_BUNDLE', None)
+    if not ca_bundle:
+      ca_bundle = os.environ.get('REQUESTS_CA_BUNDLE', None)
     if ca_bundle:
       ca_bundle = extract_zipped_paths(ca_bundle)
     if not hasattr(ssl, '_create_unverified_context'):

--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -170,15 +170,15 @@ class _Downloader(object):
       # disable ftp ssl bypassing for python version <= 2.7.8
       def disabled_py2_log_fn(*args, **kwargs):
         return logging.info(
-            "SSL bypassing not available for python version <= 2.7.8 
-            current version: {}\n Protocols affected: FTPS".format(
+            """SSL bypassing not available for python version <= 2.7.8 current version: {}
+            Protocols affected: FTPS""".format(
                 sys.version.split(' ')[0]))
 
       ssl.__dict__['_create_unverified_context'] = disabled_py2_log_fn
       ssl.__dict__['create_default_context'] = disabled_py2_log_fn
-    
+
     ca_verify = {
-        'urllib': ssl._create_unverified_context() if ca_bundle 
+        'urllib': ssl._create_unverified_context() if not ca_bundle
         else ssl.create_default_context(capath=ca_bundle),
         'requests': False if not ca_bundle else ca_bundle}
 

--- a/tensorflow_datasets/core/download/downloader_test.py
+++ b/tensorflow_datasets/core/download/downloader_test.py
@@ -67,8 +67,7 @@ class DownloaderTest(testing.TestCase):
         lambda *a, **kw: _FakeResponse(self.url, self.response, self.cookies),
     ).start()
     self.downloader._pbar_url = absltest.mock.MagicMock()
-    self.downloader._pbar_dl_size = absltest.mock.MagicMock()
-
+    self.downloader._pbar_dl_size = absltest.mock.MagicMock() 
     absltest.mock.patch.object(
         downloader.urllib.request,
         'urlopen',
@@ -82,7 +81,7 @@ class DownloaderTest(testing.TestCase):
     with open(self.path, 'rb') as result:
       self.assertEqual(result.read(), self.response)
     self.assertFalse(tf.io.gfile.exists(self.incomplete_path))
-
+  
   def test_drive_no_cookies(self):
     url = 'https://drive.google.com/uc?export=download&id=a1b2bc3'
     promise = self.downloader.download(url, self.tmp_dir)
@@ -144,6 +143,15 @@ class DownloaderTest(testing.TestCase):
     promise = self.downloader.download(url, self.tmp_dir)
     with self.assertRaises(downloader.urllib.error.URLError):
       promise.get()
+  
+  def test_ssl_mock(self):
+    ssl_mock_dict = downloader.ssl.__dict__.copy()
+    ssl_mock_dict.pop("_create_unverified_context")
+    absltest.mock.patch.dict(
+        downloader.ssl.__dict__,
+        ssl_mock_dict,
+        clear=True).start()
+    self.test_ok()
 
 
 class GetFilenameTest(testing.TestCase):


### PR DESCRIPTION
Patch in reference to #275 
Added Support to CA Files, in Downloader.
The User needs to set an environment variable `TFDS_CA_BUNDLE`. Not Setting anything will skip any CA Checking.

cc: @Conchylicultor @rsepassi @cyfra 