### PR TITLE
imdb.py fails on Windows

### DIFF
--- a/tensorflow_datasets/text/imdb.py
+++ b/tensorflow_datasets/text/imdb.py
@@ -154,7 +154,7 @@ class IMDBReviews(tfds.core.GeneratorBasedBuilder):
     """Generate IMDB examples."""
     # For labeled examples, extract the label from the path.
     reg_path = "(?P<label>neg|pos)" if labeled else "unsup"
-    reg = re.compile(os.path.join("^%s" % directory, reg_path, ""))
+    reg = re.compile(os.path.join("^%s" % directory, reg_path, "").replace("\\", "\\\\"))
     for path, imdb_f in archive:
       res = reg.match(path)
       if not res:


### PR DESCRIPTION
TF2 Tutorial fails in _generate_examples() on Windows. Function re.compile has problems with "\\" character. There is a double interpretation of "\\", so it is necessary to replace it with "\\\\" such that after double interpretation, there is only single "\".