### PR TITLE
Delete unfound reference `from __future__ import google_type_annotations'

### DIFF
--- a/tensorflow_datasets/testing/patch_camelyon.py
+++ b/tensorflow_datasets/testing/patch_camelyon.py
@@ -19,7 +19,6 @@ r"""Create fake data for Camelyon Patch dataset.
 
 from __future__ import absolute_import
 from __future__ import division
-from __future__ import google_type_annotations
 from __future__ import print_function
 
 import os


### PR DESCRIPTION
When installing package, it's given an error like this:
```
Extracting tensorflow_datasets-1.0.2-py3.6.egg to /Users/{}/PycharmProjects/tensorflow/datasets/virenv/lib/python3.6/site-packages
  File "/Users/{}/PycharmProjects/tensorflow/datasets/virenv/lib/python3.6/site-packages/tensorflow_datasets-1.0.2-py3.6.egg/tensorflow_datasets/testing/patch_camelyon.py", line 22
    from __future__ import google_type_annotations
                                                 ^
SyntaxError: future feature google_type_annotations is not defined
```
