### PR TITLE
Add TensorFlow Datasets and TF 1.14+ installation to add_dataset.md

### DIFF
--- a/docs/add_dataset.md
+++ b/docs/add_dataset.md
@@ -67,9 +67,9 @@ generate on a single machine. See the
 
 If you want to
 [contribute to our repo](https://github.com/tensorflow/datasets/blob/master/CONTRIBUTING.md)
-and add a new dataset, the following script will help you get started by
-generating the required python files,...
-To use it, clone the `tfds` repository and run the following command:
+and add a new dataset, first install TensorFlow (1.14+) and TFDS by running `pip install tensorflow tensorflow-datasets`. 
+The following script will help you get started by generating the required Python files.
+To use it, fork the `tfds` repository, clone it and run the following command:
 
 ```
 python tensorflow_datasets/scripts/create_new_dataset.py \


### PR DESCRIPTION
Suggestion to the [Add a dataset](https://www.tensorflow.org/datasets/add_dataset) guide: 

- Add `"first install TensorFlow (1.14+) and TFDS by running pip install..."` before running the `create_new_dataset.py` script. Otherwise, it will return an error: `ModuleNotFoundError: No module named 'tensorflow_datasets'`. 

The installation procedure is mentioned in the [Overview](https://www.tensorflow.org/datasets/overview) but it's not explicitly stated in [Add a dataset](https://www.tensorflow.org/datasets/add_dataset) and a user may skip the Overview before encountering this issue. 

Let me know if you have any questions.