### PR TITLE
 Add dataset-name to download_dir.

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -645,7 +645,7 @@ class DatasetBuilder(object):
 
   def _make_download_manager(self, download_dir, download_config):
     download_dir = download_dir or os.path.join(self._data_dir_root,
-                                                "downloads")
+                                                "downloads", self.name)
     extract_dir = (download_config.extract_dir or
                    os.path.join(download_dir, "extracted"))
     manual_dir = (download_config.manual_dir or

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -647,7 +647,7 @@ class DatasetBuilder(object):
     download_dir = download_dir or os.path.join(self._data_dir_root,
                                                 "downloads", self.name)
     extract_dir = (download_config.extract_dir or
-                   os.path.join(download_dir, "extracted"))
+                   os.path.join(self._data_dir_root, "extracted", self.name))
     manual_dir = (download_config.manual_dir or
                   os.path.join(download_dir, "manual"))
     manual_dir = os.path.join(manual_dir, self.name)


### PR DESCRIPTION
Downloaded files have complicated names to understand so with this offer the downloaded files will be have better names that is more understandable name.

*Old version*:
`tensorflow_datasets/downloads/openml.org_get_csv_16826755_phpMYEkMlxhfbLHRwcWJQ9vABvlEwTHa8yIFVJ6uLrnNL3KBzVzc`

*Suggested version*:
`tensorflow_datasets/downloads/titanic/openml.org_get_csv_16826755_phpMYEkMlxhfbLHRwcWJQ9vABvlEwTHa8yIFVJ6uLrnNL3KBzVzc`
