### PR TITLE
Include __version__ in __all__

### DIFF
--- a/tensorflow_datasets/public_api.py
+++ b/tensorflow_datasets/public_api.py
@@ -54,6 +54,7 @@ __all__ = [
     "testing",
     "disable_progress_bar",
     "is_dataset_on_gcs",
+    "__version__",
 ]
 
 


### PR DESCRIPTION
Self-explanatory - I believe `__version__` should be included in `__all__` so TFDS version can be checked as

    tfds.__version__

instead of

    from tensorflow_datasets import version as tfds_version
    tfds_version.__version__