### PR TITLE
Fix the link to the list of available datasets in the documentation

### DIFF
--- a/docs/api_docs/python/tfds.md
+++ b/docs/api_docs/python/tfds.md
@@ -29,7 +29,7 @@ The main library entrypoints are:
 #### Documentation:
 
 *   These API docs
-*   [Available datasets](https://github.com/tensorflow/datasets/tree/master/docs/catalog/overview.md)
+*   [Available datasets](https://www.tensorflow.org/datasets/catalog/overview)
 *   [Colab tutorial](https://colab.research.google.com/github/tensorflow/datasets/blob/master/docs/overview.ipynb)
 *   [Add a dataset](https://github.com/tensorflow/datasets/tree/master/docs/add_dataset.md)
 


### PR DESCRIPTION
The proper link is https://github.com/tensorflow/datasets/tree/master/docs/add_dataset.md