### PR TITLE
Use shutil.disk_usage instead of psutil.disk_usage for Python 3.3+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ REQUIRED_PKGS = [
     'numpy',
     'promise',
     'protobuf>=3.6.1',
-    'psutil',
     'requests>=2.19.0',
     'six',
     'tensorflow-metadata',
@@ -77,6 +76,10 @@ else:
 if sys.version_info < (3, 4):
   # enum introduced in Python 3.4
   REQUIRED_PKGS.append('enum34')
+
+if sys.version_info < (3, 3):
+  # shutil.disk_usage was introduced in Python 3.3, use psutil instead.
+  REQUIRED_PKGS.append('psutil')
 
 # Static files needed by datasets.
 DATASET_FILES = [

--- a/tensorflow_datasets/core/utils/py_utils.py
+++ b/tensorflow_datasets/core/utils/py_utils.py
@@ -29,13 +29,16 @@ import os
 import sys
 import uuid
 
-import psutil
 import six
 import tensorflow as tf
 from tensorflow_datasets.core import constants
 
 
 # pylint: disable=g-import-not-at-top
+try:
+  from shutil import disk_usage
+except ImportError:
+  from psutil import disk_usage
 if sys.version_info[0] > 2:
   import functools
 else:
@@ -338,7 +341,7 @@ def rgetattr(obj, attr, *args):
 
 def has_sufficient_disk_space(needed_bytes, directory="."):
   try:
-    free_bytes = psutil.disk_usage(os.path.abspath(directory)).free
+    free_bytes = disk_usage(os.path.abspath(directory)).free
   except OSError:
     return True
   return needed_bytes < free_bytes


### PR DESCRIPTION
I would like to propose this change to avoid the `psutil` dependency if possible. It requires a C compiler and Python development files which are not always readily available.

Related to #1053.