### PR TITLE
Fix import error

### DIFF
--- a/tensorflow_datasets/scripts/create_new_dataset.py
+++ b/tensorflow_datasets/scripts/create_new_dataset.py
@@ -30,7 +30,9 @@ import os
 from absl import app
 from absl import flags
 
-from tensorflow.io import gfile
+#from tensorflow.io import gfile
+import tensorflow
+gfile = tensorflow.io.gfile
 from tensorflow_datasets.core import naming
 from tensorflow_datasets.core.utils import py_utils
 


### PR DESCRIPTION
At for now, TensorFlow 2.0 (stable) does not allow import `io` module. Only reference it after import the `tensorflow` package.