### PR TITLE
Don't apply `os.path.normpath` to the Voc `data_path`.

### DIFF
--- a/tensorflow_datasets/object_detection/voc.py
+++ b/tensorflow_datasets/object_detection/voc.py
@@ -202,8 +202,9 @@ class Voc(tfds.core.GeneratorBasedBuilder):
 
   def _generate_examples(self, data_path, set_name):
     """Yields examples."""
-    set_filepath = os.path.normpath(os.path.join(
-        data_path, "VOCdevkit/VOC{}/ImageSets/Main/{}.txt".format(
+    set_filepath = os.path.join(
+        data_path,
+        os.path.normpath("VOCdevkit/VOC{}/ImageSets/Main/{}.txt".format(
             self.builder_config.year, set_name)))
     load_annotations = (
         self.builder_config.has_test_annotations or set_name != "test")
@@ -214,11 +215,13 @@ class Voc(tfds.core.GeneratorBasedBuilder):
         yield image_id, example
 
   def _generate_example(self, data_path, image_id, load_annotations):
-    image_filepath = os.path.normpath(os.path.join(
-        data_path, "VOCdevkit/VOC{}/JPEGImages/{}.jpg".format(
+    image_filepath = os.path.join(
+        data_path,
+        os.path.normpath("VOCdevkit/VOC{}/JPEGImages/{}.jpg".format(
             self.builder_config.year, image_id)))
-    annon_filepath = os.path.normpath(os.path.join(
-        data_path, "VOCdevkit/VOC{}/Annotations/{}.xml".format(
+    annon_filepath = os.path.join(
+        data_path,
+        os.path.normpath("VOCdevkit/VOC{}/Annotations/{}.xml".format(
             self.builder_config.year, image_id)))
     if load_annotations:
       objects = list(_get_example_objects(annon_filepath))


### PR DESCRIPTION
`download_and_prepare()` breaks with the current Voc implementation if the `data_dir` is set to a Google Cloud Storage URI.

E.g., running `tfds.builder("voc/2007:4.0.0", data_dir="gs://SOME/GCP/PATH").download_and_prepare()` results in the following error:

```bash
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/tensorflow_datasets/core/api_utils.py", line 52, in disallow_positional_args_dec
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/tensorflow_datasets/core/dataset_builder.py", line 287, in download_and_prepare
    download_config=download_config)
  File "/usr/local/lib/python3.7/site-packages/tensorflow_datasets/core/dataset_builder.py", line 937, in _download_and_prepare
    max_examples_per_split=download_config.max_examples_per_split,
  File "/usr/local/lib/python3.7/site-packages/tensorflow_datasets/core/dataset_builder.py", line 805, in _download_and_prepare
    self._prepare_split(split_generator, **prepare_split_kwargs)
  File "/usr/local/lib/python3.7/site-packages/tensorflow_datasets/core/dataset_builder.py", line 962, in _prepare_split
    total=split_info.num_examples, leave=False):
  File "/usr/local/lib/python3.7/site-packages/tqdm/std.py", line 1087, in __iter__
    for obj in iterable:
  File "/usr/local/lib/python3.7/site-packages/tensorflow_datasets/image/voc.py", line 207, in _generate_examples
    for line in f:
  File "/usr/local/lib/python3.7/site-packages/tensorflow_core/python/lib/io/file_io.py", line 220, in __next__
    return self.next()
  File "/usr/local/lib/python3.7/site-packages/tensorflow_core/python/lib/io/file_io.py", line 214, in next
    retval = self.readline()
  File "/usr/local/lib/python3.7/site-packages/tensorflow_core/python/lib/io/file_io.py", line 178, in readline
    self._preread_check()
  File "/usr/local/lib/python3.7/site-packages/tensorflow_core/python/lib/io/file_io.py", line 84, in _preread_check
    compat.as_bytes(self.__name), 1024 * 512)
tensorflow.python.framework.errors_impl.NotFoundError: gs:/SOME/GCP/PATH/downloads/extracted/TAR.pjreddi.com_media_files_VOCtest_6-Nov-2007aDaIji4B3KhFd6hJ0zn6T3Ph5PE10xJDDEhWtWCbSJI.tar/VOCdevkit/VOC2007/ImageSets/Main/test.txt; No such file or directory
```

The error is caused by the use of `os.path.normpath` in the following line: https://github.com/tensorflow/datasets/blob/d4e0e83a2c7b5ee8b807d036493ef0329e8f446e/tensorflow_datasets/object_detection/voc.py#L205-L207

It arises because `os.path.normpath` converts double slashes `//` to single slashes `/` and so `gs://SOME/GCP/...` becomes `gs:/SOME/GCP/...`.

This PR fixes the issue by swapping the order of `os.path.normpath` and `os.path.join` so that the path normalisation is not applied to the `data_path` prefix, which potentially contains the `gs://...` string.

@Conchylicultor thoughts?
