### PR TITLE
Added Carvana Masking Challenge dataset

### DIFF
--- a/tensorflow_datasets/image/__init__.py
+++ b/tensorflow_datasets/image/__init__.py
@@ -23,6 +23,7 @@ from tensorflow_datasets.image.binary_alpha_digits import BinaryAlphaDigits
 from tensorflow_datasets.image.caltech import Caltech101
 from tensorflow_datasets.image.caltech_birds import CaltechBirds2010
 from tensorflow_datasets.image.cars196 import Cars196
+from tensorflow_datasets.image.carvana import Carvana
 from tensorflow_datasets.image.cassava import Cassava
 from tensorflow_datasets.image.cats_vs_dogs import CatsVsDogs
 from tensorflow_datasets.image.cbis_ddsm import CuratedBreastImagingDDSM
@@ -86,3 +87,4 @@ from tensorflow_datasets.image.svhn import SvhnCropped
 from tensorflow_datasets.image.the300w_lp import The300wLp
 from tensorflow_datasets.image.uc_merced import UcMerced
 from tensorflow_datasets.image.visual_domain_decathlon import VisualDomainDecathlon
+

--- a/tensorflow_datasets/image/carvana.py
+++ b/tensorflow_datasets/image/carvana.py
@@ -25,6 +25,7 @@ _URL = "https://www.kaggle.com/c/carvana-image-masking-challenge"
 
 _CITATION = r"this dataset does not provide a citation."
 
+
 class Carvana(tfds.core.GeneratorBasedBuilder):
     """Carvana Image Masking Challenge."""
 
@@ -80,6 +81,7 @@ class Carvana(tfds.core.GeneratorBasedBuilder):
         metadata = tf.io.gfile.GFile(metadata_file)
         metadata = metadata.readlines()[1:]
         metadata = (m.strip().split(',') for m in metadata)
+        # the [1:-1] is to crop the " at each label
         metadata = {
             id[1:-1]: {'year': year[1:-1],
                        'make': make[1:-1],

--- a/tensorflow_datasets/image/carvana.py
+++ b/tensorflow_datasets/image/carvana.py
@@ -23,22 +23,21 @@ _DESCRIPTION = """Automatically identify the boundaries of the car in an image."
 
 _URL = "https://www.kaggle.com/c/carvana-image-masking-challenge"
 
-_CITATION = r"""this dataset does not provide a citation."""
-
+_CITATION = r"this dataset does not provide a citation."
 
 class Carvana(tfds.core.GeneratorBasedBuilder):
     """Carvana Image Masking Challenge."""
 
-    VERSION = tfds.core.Version("1.0.1")
+    VERSION = tfds.core.Version("1.0.0")
 
     def _info(self):
         return tfds.core.DatasetInfo(
             builder=self,
             description=_DESCRIPTION,
             features=tfds.features.FeaturesDict({
-                'image': tfds.features.Image(shape=(None, None, 3), dtype=tf.uint8),
+                'image': tfds.features.Image(shape=(1280, 1920, 3), dtype=tf.uint8),
                 'mask/rle': tfds.features.Sequence(tf.int32),
-                'mask': tfds.features.Image(shape=(1, None, None, 3), dtype=tf.uint8),
+                'mask': tfds.features.Image(shape=(1, 1280, 1920, 3), dtype=tf.uint8),
                 'rotation': tf.uint8,
                 'metadata': {
                     'model': tf.string,
@@ -103,7 +102,9 @@ class Carvana(tfds.core.GeneratorBasedBuilder):
         metadata = self._read_metadata(metadata_file)
         masks_rle = self._read_masks_rle(masks_lre_file)
 
-        for img in tf.io.gfile.listdir(images_dir):
+        images = tf.io.gfile.listdir(images_dir)
+
+        for img in sorted(images):
             name, _ext = os.path.splitext(img)
             id, rotation = name.split('_')
             rotation = int(rotation) - 1

--- a/tensorflow_datasets/image/carvana.py
+++ b/tensorflow_datasets/image/carvana.py
@@ -19,7 +19,9 @@ import os
 import tensorflow as tf
 import tensorflow_datasets.public_api as tfds
 
-_DESCRIPTION = """Automatically identify the boundaries of the car in an image."""
+_DESCRIPTION = ("Automatically identify the boundaries of the car in an image. "
+                "This data is provided by a competition by Kaggle. "
+                "Both the masks and the polylines are provided in this dataset.")
 
 _URL = "https://www.kaggle.com/c/carvana-image-masking-challenge"
 

--- a/tensorflow_datasets/image/carvana.py
+++ b/tensorflow_datasets/image/carvana.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+# Copyright 2019 The TensorFlow Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Carvana Image Masking Challenge"""
+
+import os
+import tensorflow as tf
+import tensorflow_datasets.public_api as tfds
+
+_DESCRIPTION = """Automatically identify the boundaries of the car in an image."""
+
+_URL = "https://www.kaggle.com/c/carvana-image-masking-challenge"
+
+_CITATION = r"""this dataset does not provide a citation."""
+
+
+class Carvana(tfds.core.GeneratorBasedBuilder):
+    """Carvana Image Masking Challenge."""
+
+    VERSION = tfds.core.Version("1.0.1")
+
+    def _info(self):
+        return tfds.core.DatasetInfo(
+            builder=self,
+            description=_DESCRIPTION,
+            features=tfds.features.FeaturesDict({
+                'image': tfds.features.Image(shape=(None, None, 3), dtype=tf.uint8),
+                'mask/rle': tfds.features.Sequence(tf.int32),
+                'mask': tfds.features.Image(shape=(1, None, None, 3), dtype=tf.uint8),
+                'rotation': tf.uint8,
+                'metadata': {
+                    'model': tf.string,
+                    'make': tf.string,
+                    'year': tf.string,
+                    'trim1': tf.string,
+                    'trim2': tf.string,
+                }
+            }),
+            supervised_keys=("image", "mask"),
+            homepage=_URL,
+            citation=None
+        )
+
+    def _split_generators(self, dl_manager: tfds.download.DownloadManager):
+        dl_paths = dl_manager.download_kaggle_data(
+            "carvana-image-masking-challenge")
+
+        data_dir = dl_manager.extract({
+            'metadata': dl_paths['metadata.csv.zip'],
+            'images_train': dl_paths['train_hq.zip'],
+            'images_test': dl_paths['test.zip'],
+            'masks_train': dl_paths['train_masks.zip'],
+            'masks_lre_train': dl_paths['train_masks.csv.zip'],
+        })
+
+        return [
+            tfds.core.SplitGenerator(
+                name=tfds.Split.TRAIN,
+                gen_kwargs={
+                    'images_dir': os.path.join(data_dir['images_train'], 'train_hq'),
+                    'masks_dir': os.path.join(data_dir['masks_train'], 'train_masks'),
+                    'metadata_file': os.path.join(data_dir['metadata'], 'metadata.csv'),
+                    'masks_lre_file': os.path.join(data_dir['masks_lre_train'], 'train_masks.csv')
+                }
+            )
+        ]
+
+    def _read_metadata(self, metadata_file):
+        metadata = tf.io.gfile.GFile(metadata_file)
+        metadata = metadata.readlines()[1:]
+        metadata = (m.strip().split(',') for m in metadata)
+        metadata = {
+            id[1:-1]: {'year': year[1:-1],
+                       'make': make[1:-1],
+                       'model': model[1:-1],
+                       'trim1': trim1[1:-1],
+                       'trim2': trim2[1:-1]
+                       }
+            for id, year, make, model, trim1, trim2 in metadata}
+        return metadata
+
+    def _read_masks_rle(self, masks_file):
+        masks = tf.io.gfile.GFile(masks_file)
+        masks = masks.readlines()[1:]
+        masks = [line.split(',') for line in masks]
+        masks = {id: [int(p) for p in points.split(' ')]
+                 for id, points in masks}
+        return masks
+
+    def _generate_examples(self, metadata_file, images_dir, masks_dir, masks_lre_file):
+        metadata = self._read_metadata(metadata_file)
+        masks_rle = self._read_masks_rle(masks_lre_file)
+
+        for img in tf.io.gfile.listdir(images_dir):
+            name, _ext = os.path.splitext(img)
+            id, rotation = name.split('_')
+            rotation = int(rotation) - 1
+            meta = metadata[id]
+
+            yield name, {
+                'image': os.path.join(images_dir, img),
+                'mask': os.path.join(masks_dir, f'{name}_mask.gif'),
+                'mask/rle': masks_rle[img],
+                'rotation': rotation,
+                'metadata': meta,
+            }

--- a/tensorflow_datasets/image/carvana_test.py
+++ b/tensorflow_datasets/image/carvana_test.py
@@ -1,0 +1,6 @@
+import tensorflow as tf
+from tensorflow_datasets import carvana
+import tensorflow_datasets.testing as tfds_test
+
+class CarvanaTest(tfds_test.DatasetBuilderTestCase):
+    DATASET_CLASS = carvana.Carvana

--- a/tensorflow_datasets/image/carvana_test.py
+++ b/tensorflow_datasets/image/carvana_test.py
@@ -1,6 +1,11 @@
 import tensorflow as tf
-from tensorflow_datasets import carvana
+from tensorflow_datasets.image import carvana
 import tensorflow_datasets.testing as tfds_test
 
 class CarvanaTest(tfds_test.DatasetBuilderTestCase):
     DATASET_CLASS = carvana.Carvana
+
+    # TODO
+
+if __name__ == '__main__':
+    tfds_test.test_main()

--- a/tensorflow_datasets/url_checksums/carvana.txt
+++ b/tensorflow_datasets/url_checksums/carvana.txt
@@ -1,0 +1,9 @@
+kaggle://carvana-image-masking-challenge/29bb3ece3180_11.jpg 109920 23e473f7d4aac81292ae9720a42ba75323201a5557b668b22ad824b2bcee0a3a
+kaggle://carvana-image-masking-challenge/metadata.csv.zip 83109 85d62bbcd8e2b05e8b1921d6cb9e7fc30280961d1ca2360150f33d2c33800a31
+kaggle://carvana-image-masking-challenge/sample_submission.csv.zip 206457 3e0fb0e43f65dbfc1f5ce9031bff8ea22736995e5aa815547533f77db0bc0c7e
+kaggle://carvana-image-masking-challenge/test.zip 8328838743 aa239196937f7b31c1121e1e2fb0cd5f6645c52f58ebb6739fd3be2d6b4ecde3
+kaggle://carvana-image-masking-challenge/test_hq.zip 16588751874 1925380468a8c42b90ebb62cce3fedc068b126ca29c789933df824fe3d190f6f
+kaggle://carvana-image-masking-challenge/train.zip 424233528 dcb524b44ad0e70af0d89d6d41384ca9a5f483456717b2ba4591eefcdffbc80e
+kaggle://carvana-image-masking-challenge/train_hq.zip 843301716 96ef74e3e4c2ab9404a0ea3cff672a9f5b1a1ed7eec4a0b3035c941ee2388358
+kaggle://carvana-image-masking-challenge/train_masks.csv.zip 16001807 de18974479e0e6dbad4f9384364256687d53cda5627a4622d48f25d9440e92cb
+kaggle://carvana-image-masking-challenge/train_masks.zip 30537860 01b6748a4fd68757e381bfa3ae77ddfba4a62521cc3ea8f31c5842591bc2fc2d


### PR DESCRIPTION
This is the Carvana Masking Challenge dataset from the kaggle competition of the same name. I think it is a great dataset to start with FCN, such as UNet.
The dataset has 20Gb of data, with images, masks, and also RLE masks. 

Some issues:
- There is no train/validation split in the dataset.
- There are two sets of images, one with low quality (not used), and one with higher quality (used).
- There are no tests yet.
- No citation is provided.