### PR TITLE
Fix numbers in Oxford Flowers 102 description

### DIFF
--- a/tensorflow_datasets/image/oxford_flowers102.py
+++ b/tensorflow_datasets/image/oxford_flowers102.py
@@ -43,8 +43,8 @@ large scale, pose and light variations. In addition, there are categories that h
 variations within the category and several very similar categories.
 
 The dataset is divided into a training set, a validation set and a test set.
-The training set and validation set each consist of 10 images per class (totalling 1030 images each).
-The test set consist of the remaining 6129 images (minimum 20 per class).
+The training set and validation set each consist of 10 images per class (totalling 1020 images each).
+The test set consists of the remaining 6149 images (minimum 20 per class).
 """
 
 


### PR DESCRIPTION
Not sure if you automatically generate [md](https://github.com/tensorflow/datasets/blob/master/docs/catalog/oxford_flowers102.md) and json files ([1](https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/testing/metadata/oxford_flowers102/0.0.1/dataset_info.json), [2](https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/testing/metadata/oxford_flowers102/1.0.0/dataset_info.json), [3](https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/testing/metadata/oxford_flowers102/2.0.0/dataset_info.json)) from source. If needed I can correct them too.