### PR TITLE
TextTokenEncoder cannot recover from files saved by itself

### DIFF
--- a/tensorflow_datasets/core/features/text/text_encoder.py
+++ b/tensorflow_datasets/core/features/text/text_encoder.py
@@ -344,12 +344,12 @@ class TokenTextEncoder(TextEncoder):
     self._write_lines_to_file(filename, self._vocab_list, kwargs)
 
   @classmethod
-  def load_from_file(cls, filename_prefix):
+  def load_from_file(cls, filename_prefix, tokenizer_cls=None):
     filename = cls._filename(filename_prefix)
     vocab_lines, kwargs = cls._read_lines_from_file(filename)
     has_tokenizer = kwargs.pop("has_tokenizer", False)
     if has_tokenizer:
-      kwargs["tokenizer"] = Tokenizer.load_from_file(filename)
+      kwargs["tokenizer"] = (tokenizer_cls or Tokenizer).load_from_file(filename)
     return cls(vocab_list=vocab_lines, **kwargs)
 
 


### PR DESCRIPTION
**Short description**
I use a custom tokenizer and inherit the `tfds.features.text.Tokenizer` class. And distribute it to the `tfds.features.text.TextTokenEncoder` object. The object can `save_to_file` normally. However, it cannot be recovered from the file.

**Environment information**
* Operating System: ubuntu
* Python version: 3.6.4
* `tensorflow-datasets`/`tfds-nightly` version: both is 1.3.2
* `tensorflow`/`tensorflow-gpu`/`tf-nightly`/`tf-nightly-gpu` version: 2.0

**Reproduction instructions**

```
import tensorflow_datasets as tfds


class MyTokenizer(tfds.features.text.Tokenizer):
    pass


# tokenizer = tfds.features.text.Tokenizer()
tokenizer = MyTokenizer()

s = "I love nlp! "
vocab_list = tokenizer.tokenize(s)

token_text_encoder = tfds.features.text.TokenTextEncoder(vocab_list=vocab_list, tokenizer=tokenizer)

token_text_encoder.save_to_file('encoder')

restore_encoder = tfds.features.text.TokenTextEncoder.load_from_file('encoder')

words = restore_encoder.tokenizer.tokenize(s)
print(words)

```

**Link to logs**
This colab has the error message:
https://colab.research.google.com/drive/1ELGt30Wrr0jqgE44W41T_aWTAbWHCZQ4#scrollTo=xSSAIUdvrVJn

The error message is:
ValueError: File encoder.tokens.tokenizer does not seem to have been created from Tokenizer.save_to_file.

**Expected behavior**
The encoder can be restored from the file generated by save_to_file function.

**Additional context**
In the end, I found that the reason why it cannot be recovered is that in the TextTokenEncoder class, the tokenizer is always recovered through the `tfds.features.text.Tokenizer` class. This is not consistent with the generality of save_to_file function.
