### PR TITLE
update dataset_info.json instructions

### DIFF
--- a/docs/add_dataset.md
+++ b/docs/add_dataset.md
@@ -506,7 +506,7 @@ python -m tensorflow_datasets.scripts.download_and_prepare \
 
 Note that the `--register_checksums` flag must only be used while in development.
 
-Copy in the contents of the `dataset_info.json` file(s) to the ```testing/metadata``` subdirectory for the dataset.
+The contents of the `dataset_info.json` file(s) should be in the ```tensorflow_datasets/testing/metadata``` subdirectory for the dataset.
 
 
 ### 3. Double-check the citation

--- a/docs/add_dataset.md
+++ b/docs/add_dataset.md
@@ -506,7 +506,7 @@ python -m tensorflow_datasets.scripts.download_and_prepare \
 
 Note that the `--register_checksums` flag must only be used while in development.
 
-Copy in the contents of the `dataset_info.json` file(s) to a [GitHub gist](https://gist.github.com/) and link to it in your pull request.
+Copy in the contents of the `dataset_info.json` file(s) to the ```testing/metadata``` subdirectory for the dataset.
 
 
 ### 3. Double-check the citation


### PR DESCRIPTION
Previously, the instructions for adding a dataset instructed users to create a Github Gist for the ```dataset_info.json``` files. However  I don't see the use of this as they should be added to the ```tensorflow_datasets/testing/metadata``` subdirectory for the dataset.  Updated the instructions to reflect this.