### PR TITLE
[tensorflow_datasets/core/dataset_builder.py] Add no GCS support

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -197,6 +197,11 @@ class DatasetBuilder(object):
     if tf.io.gfile.exists(self._data_dir):
       logging.info("Overwrite dataset info from restored data version.")
       self.info.read_from_directory(self._data_dir)
+    elif os.path.isdir((lambda drive_directory: os.path.join(drive_directory[0],
+                                                             drive_directory[1][:drive_directory[1].find(os.path.sep,
+                                                                                                         1)])
+                       )(os.path.splitdrive(self._data_dir))):
+      logging.info("No dataset found at this disk location.")
     else:  # Use the code version (do not restore data)
       logging.info("Load pre-computed datasetinfo (eg: splits) from bucket.")
       self.info.initialize_from_bucket()


### PR DESCRIPTION
Was working on the train en route to the hospital, and noticed that this error:
> requests.exceptions.ConnectionError: HTTPConnectionPool(host='storage.googleapis.com', port=80): Max retries exceeded with url: /tfds-data/?prefix=dataset_info/DS%20NAME/1.0.0/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1428de7d0>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))

Even though my dataset is found locally on my laptop and `try_download_gcs is False`.

This PR checks to see if the highest parent directory of `data_dir` exists, and if it does assumes that it's not a GCS directory.