### PR TITLE
Add 3.0.0 to fashion_mnist & kmnist

### DIFF
--- a/tensorflow_datasets/image/mnist.py
+++ b/tensorflow_datasets/image/mnist.py
@@ -174,6 +174,10 @@ class FashionMNIST(MNIST):
   VERSION = tfds.core.Version("1.0.0",
                               experiments={tfds.core.Experiment.S3: False})
 
+  SUPPORTED_VERSIONS = [
+      tfds.core.Version("3.0.0", "S3: www.tensorflow.org/datasets/splits"),
+  ]
+
   # TODO(afrozm): Try to inherit from MNIST's _info and mutate things as needed.
   def _info(self):
     return tfds.core.DatasetInfo(
@@ -203,6 +207,10 @@ class KMNIST(MNIST):
 
   VERSION = tfds.core.Version("1.0.0",
                               experiments={tfds.core.Experiment.S3: False})
+
+  SUPPORTED_VERSIONS = [
+      tfds.core.Version("3.0.0", "S3: www.tensorflow.org/datasets/splits"),
+  ]
 
   def _info(self):
     return tfds.core.DatasetInfo(


### PR DESCRIPTION
The documentation currently claims that both `fashion_mnist` and `kmnist` support the S3 API through version 3.0.0, since they inherit directly from the builder for MNIST. However, neither includes an S3 compatible version in their `SUPPORTED_VERSIONS`.  This PR adds the 3.0.0 version to both, fixing the discrepancy.

Happy to add a test or two, but felt that the existing tests were sufficient.  Works on Ubuntu with TF 2.0.0 & Python 3.5.