### PR TITLE
fix typo and missing link

### DIFF
--- a/docs/performances.md
+++ b/docs/performances.md
@@ -1,4 +1,4 @@
-# Performances tips
+# Performance tips
 
 This document provides TFDS-specific performance tips. Note that TFDS provides
 datasets as `tf.data.Dataset`s, so the advice from the
@@ -59,7 +59,7 @@ By default, TFDS auto-caches datasets which satisfy the following constraints:
 *   `shuffle_files` is disabled, or only a single shard is read
 
 It is possible to opt out of auto-caching by passing
-`read_config=tfds.ReadConfig(try_autocaching=False)` to `tfds.load`. Have a look
+[`read_config=tfds.ReadConfig(try_autocaching=False)`](https://www.tensorflow.org/datasets/api_docs/python/tfds/ReadConfig) to `tfds.load`. Have a look
 at the dataset catalog documentation to see if a specific dataset will use
 auto-cache.
 


### PR DESCRIPTION
@Conchylicultor : please review.
fixed the typo on the title because in the navbar it's written performance tips.
also added the broken link.
wanted to ask if i want to add more links which are missing where do i add directly in Markdown or there is a separate file which is generated during testing of docs?