### PR TITLE
download_manager doesn't append name to manual_dir

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -755,8 +755,8 @@ class DatasetBuilder(object):
     # Use manual_dir only if MANUAL_DOWNLOAD_INSTRUCTIONS are set.
     if self.MANUAL_DOWNLOAD_INSTRUCTIONS:
       manual_dir = (
-          download_config.manual_dir or os.path.join(download_dir, "manual"))
-      manual_dir = os.path.join(manual_dir, self.name)
+          download_config.manual_dir or
+        os.path.join(download_dir, "manual",self.name))
     else:
       manual_dir = None
 


### PR DESCRIPTION
related to issue https://github.com/tensorflow/datasets/issues/587

I tested it with manual_dir using 

python -m tensorflow_datasets.scripts.download_and_prepare   --register_checksums   --datasets=flores --manual_dir=/home/dhirensr/tensorflow_datasets/downloads/face_flor_raw_mast_wiki_en_ne_si_test_setsegJFuyn9A7RqESmDHBg9-6DvyEUqlznZYnWfJRQapkg.tgz

