### PR TITLE
Remove python 2 legacy from download_manager.py

### DIFF
--- a/tensorflow_datasets/core/download/download_manager.py
+++ b/tensorflow_datasets/core/download/download_manager.py
@@ -16,9 +16,6 @@
 # Lint as: python3
 """Download manager interface."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import sys
@@ -388,11 +385,9 @@ class DownloadManager(object):
               self._manual_dir, self._manual_dir_instructions))
     return self._manual_dir
 
-  
-if sys.version_info[0] > 2:
 
-  def _wait_on_promise(p):
-    return p.get()
+def _wait_on_promise(p):
+  return p.get()
 
 def _map_promise(map_fn, all_inputs):
   """Map the function into each element and resolve the promise."""

--- a/tensorflow_datasets/core/download/download_manager.py
+++ b/tensorflow_datasets/core/download/download_manager.py
@@ -389,29 +389,7 @@ class DownloadManager(object):
     return self._manual_dir
 
 
-# ============================================================================
-# In Python 2.X, threading.Condition.wait() cannot be interrupted by SIGINT,
-# unless it's given a timeout. Here we artificially give a long timeout to
-# allow ctrl+C.
-# This code should be deleted once python2 is no longer supported.
-if sys.version_info[0] > 2:
-
-  def _wait_on_promise(p):
-    return p.get()
-
-else:
-
-  def _wait_on_promise(p):
-    while True:
-      result = p.get(sys.maxint)  # pylint: disable=g-deprecated-member-used
-      if p.is_fulfilled:
-        return result
-
-# ============================================================================
-
-
 def _map_promise(map_fn, all_inputs):
   """Map the function into each element and resolve the promise."""
   all_promises = utils.map_nested(map_fn, all_inputs)  # Apply the function
-  res = utils.map_nested(_wait_on_promise, all_promises)
-  return res
+  return all_promises

--- a/tensorflow_datasets/core/download/download_manager.py
+++ b/tensorflow_datasets/core/download/download_manager.py
@@ -388,8 +388,14 @@ class DownloadManager(object):
               self._manual_dir, self._manual_dir_instructions))
     return self._manual_dir
 
+  
+if sys.version_info[0] > 2:
+
+  def _wait_on_promise(p):
+    return p.get()
 
 def _map_promise(map_fn, all_inputs):
   """Map the function into each element and resolve the promise."""
   all_promises = utils.map_nested(map_fn, all_inputs)  # Apply the function
-  return all_promises
+  res = utils.map_nested(_wait_on_promise, all_promises)
+  return res


### PR DESCRIPTION
As python 2 use is been dropped. So Remove unnecessary code from `download_manager.py` .

@Conchylicultor please have a look  