### PR TITLE
Add label names for oxford_flowers102

### DIFF
--- a/tensorflow_datasets/image/oxford_flowers102.py
+++ b/tensorflow_datasets/image/oxford_flowers102.py
@@ -27,6 +27,33 @@ import tensorflow_datasets.public_api as tfds
 
 _BASE_URL = "https://www.robots.ox.ac.uk/~vgg/data/flowers/102/"
 
+_NAMES = [
+    "pink primrose", "hard-leaved pocket orchid", "canterbury bells",
+    "sweet pea", "english marigold", "tiger lily", "moon orchid",
+    "bird of paradise", "monkshood", "globe thistle", "snapdragon",
+    "colt's foot", "king protea", "spear thistle", "yellow iris",
+    "globe-flower", "purple coneflower", "peruvian lily", "balloon flower",
+    "giant white arum lily", "fire lily", "pincushion flower", "fritillary",
+    "red ginger", "grape hyacinth", "corn poppy", "prince of wales feathers",
+    "stemless gentian", "artichoke", "sweet william", "carnation",
+    "garden phlox", "love in the mist", "mexican aster", "alpine sea holly",
+    "ruby-lipped cattleya", "cape flower", "great masterwort", "siam tulip",
+    "lenten rose", "barbeton daisy", "daffodil", "sword lily", "poinsettia",
+    "bolero deep blue", "wallflower", "marigold", "buttercup", "oxeye daisy",
+    "common dandelion", "petunia", "wild pansy", "primula", "sunflower",
+    "pelargonium", "bishop of llandaff", "gaura", "geranium", "orange dahlia",
+    "pink-yellow dahlia?", "cautleya spicata", "japanese anemone",
+    "black-eyed susan", "silverbush", "californian poppy", "osteospermum",
+    "spring crocus", "bearded iris", "windflower", "tree poppy", "gazania",
+    "azalea", "water lily", "rose", "thorn apple", "morning glory",
+    "passion flower", "lotus", "toad lily", "anthurium", "frangipani",
+    "clematis", "hibiscus", "columbine", "desert-rose", "tree mallow",
+    "magnolia", "cyclamen", "watercress", "canna lily", "hippeastrum",
+    "bee balm", "ball moss", "foxglove", "bougainvillea", "camellia", "mallow",
+    "mexican petunia", "bromelia", "blanket flower", "trumpet creeper",
+    "blackberry lily"
+]
+
 _CITATION = """\
 @InProceedings{Nilsback08,
    author = "Nilsback, M-E. and Zisserman, A.",
@@ -53,7 +80,7 @@ class OxfordFlowers102(tfds.core.GeneratorBasedBuilder):
   """Oxford 102 category flower dataset."""
 
   VERSION = tfds.core.Version(
-      "2.0.0", "New split API (https://tensorflow.org/datasets/splits)")
+      "2.1.0", "Added label names")
 
   def _info(self):
     return tfds.core.DatasetInfo(
@@ -61,7 +88,7 @@ class OxfordFlowers102(tfds.core.GeneratorBasedBuilder):
         description=_DESCRIPTION,
         features=tfds.features.FeaturesDict({
             "image": tfds.features.Image(),
-            "label": tfds.features.ClassLabel(num_classes=102),
+            "label": tfds.features.ClassLabel(names=_NAMES),
             "file_name": tfds.features.Text(),
         }),
         supervised_keys=("image", "label"),


### PR DESCRIPTION
Add label names for  oxford_flowers102

There is no official mapping from label names to label ids. One can infer most of the labels
by mapping their counts reported [here](http://www.robots.ox.ac.uk/~vgg/data/flowers/102/categories.html). For labels where 
the counts are the same, the distinction has to be done manually.

Therefore, I created [this colab](https://colab.research.google.com/drive/1im7E4YVNIpwRMpWrG5PyITRmnU0Lliq8#scrollTo=-ZIcYfktkBGo) to verify and demonstrate that the mapping from label ids to label names is correct.