### PR TITLE
Correct checking of image mode (RGBA)

### DIFF
--- a/tensorflow_datasets/scripts/replace_fake_images.py
+++ b/tensorflow_datasets/scripts/replace_fake_images.py
@@ -52,7 +52,7 @@ def rewrite_image(filepath):
   image = np.array(PIL.Image.open(filepath))
 
   # Filter unsuported images
-  if PIL.Image.open(filepath) == 'RGBA' or image.dtype == np.bool:
+  if PIL.Image.open(filepath).mode == 'RGBA' or image.dtype == np.bool:
     return
 
   # The color is a deterministic function of the relative filepath.

--- a/tensorflow_datasets/scripts/replace_fake_images.py
+++ b/tensorflow_datasets/scripts/replace_fake_images.py
@@ -52,7 +52,7 @@ def rewrite_image(filepath):
   image = np.array(PIL.Image.open(filepath))
 
   # Filter unsuported images
-  if image.mode == 'RGBA' or image.dtype == np.bool:
+  if PIL.Image.open(filepath) == 'RGBA' or image.dtype == np.bool:
     return
 
   # The color is a deterministic function of the relative filepath.


### PR DESCRIPTION
Fixes #1667 Replace `np.array().mode` by `PIL.Image.open(filepath)`