### PR TITLE
Better compression of .tar and .zip files

### DIFF
--- a/tensorflow_datasets/scripts/replace_fake_images.py
+++ b/tensorflow_datasets/scripts/replace_fake_images.py
@@ -104,10 +104,9 @@ def rewrite_tar(root_dir, tar_filepath):
     # Checking the extension of file to be extract
     if tar_filepath.lower().endswith('gz'):
       extension = ':gz'
-    elif tar_filepath.lower().endswith('bz2'):
+    if tar_filepath.lower().endswith('bz2'):
       extension = ':bz2'
-    else:
-      extension = ''
+    extension = ''
 
     # Extraction of .tar file
     with tarfile.open(tar_filepath, 'r' + extension) as tar:
@@ -116,8 +115,8 @@ def rewrite_tar(root_dir, tar_filepath):
     rewrite_dir(temp_dir)  # Recursivelly compress the archive content
 
     # Converting into tarfile again to decrease the space taken by the file-
-    with tarfile.open(tar_filepath, 'w' + extension) as tar:
-      tar.add(temp_dir, recursive=True)
+    with tarfile.open(tar_filepath, 'w:gz') as tar:
+      tar.add(temp_dir, recursive=True,arcname=os.path.basename(temp_dir))
 
 
 def rewrite_dir(fake_dir):
@@ -134,11 +133,11 @@ def rewrite_dir(fake_dir):
       img_ext = os.path.basename(file).split('.')[-1].lower()
       if img_ext in img_ext_list:
         rewrite_image(path)
-      elif path.endswith('.npz'):  # Filter `.npz` files
+      if path.endswith('.npz'):  # Filter `.npz` files
         continue
-      elif zipfile.is_zipfile(path):
+      if zipfile.is_zipfile(path):
         rewrite_zip(root_dir, path)
-      elif tarfile.is_tarfile(path):
+      if tarfile.is_tarfile(path):
         rewrite_tar(root_dir, path)
 
 

--- a/tensorflow_datasets/scripts/replace_fake_images.py
+++ b/tensorflow_datasets/scripts/replace_fake_images.py
@@ -82,7 +82,7 @@ def rewrite_zip(root_dir, zip_filepath):
     rewrite_dir(temp_dir)  # Recursivelly compress the archive content
 
     # Compressed the .zip file again
-    with zipfile.ZipFile(zip_filepath, 'w') as zip_file:
+    with zipfile.ZipFile(zip_filepath, 'w',compression=zipfile.ZIP_DEFLATED) as zip_file:
       for file_dir, _, files in os.walk(temp_dir):
         for file in files:
           file_path = os.path.join(file_dir, file)

--- a/tensorflow_datasets/scripts/replace_fake_images.py
+++ b/tensorflow_datasets/scripts/replace_fake_images.py
@@ -52,7 +52,7 @@ def rewrite_image(filepath):
   image = np.array(PIL.Image.open(filepath))
 
   # Filter unsuported images
-  if image.mode == 'RGBA' or image.dtype == np.bool:
+  if PIL.Image.open(filepath).mode == 'RGBA' or image.dtype == np.bool:
     return
 
   # The color is a deterministic function of the relative filepath.


### PR DESCRIPTION
Fixes #1666  @Conchylicultor  Please have a look. Below I mention changes I done in `replace_fake_images.py`

1. Add `compression=zipfile.ZIP_DEFLATED` in `rewrite_zip` function which re compresses files in efficient way than previous.

2. Add `'w:gz'` & `arcname=os.path.basename(temp_dir)` in `rewrite_tar` function 

It solves problem related to all type of `tar `and `zip `files.