### PR TITLE
Added partial visualisation for Audio Datasets under tfds

### DIFF
--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -124,11 +124,11 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     
         
   ## IMAGE VISUALIZATION 
-  if len(image_keys) > 1:
-    raise ValueError(
-        "Multiple image features detected in the dataset. Using the first one. You can "
-        "use `image_key` argument to override. Images detected: %s" %
-        (",".join(image_keys)))
+#   if len(image_keys) > 1:
+#     raise ValueError(
+#         "Multiple image features detected in the dataset. Using the first one. You can "
+#         "use `image_key` argument to override. Images detected: %s" %
+#         (",".join(image_keys)))
 
   image_key = image_keys[0]
 

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -133,11 +133,11 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     audio_keys = [
     k for k, feature in ds_info.features.items()
     if isinstance(feature,features_lib.Audio)]
-
-    if not audio_keys: 
-      raise ValueError(
-        "Visualisation not supported for dataset `{}`. Was not able to "
-        "auto-infer the audio.".format(ds_info.name))
+   
+#     if not audio_keys: 
+#       raise ValueError(
+#         "Visualisation not supported for dataset `{}`. Was not able to "
+#         "auto-infer the audio.".format(ds_info.name))
 
     audio_samples=[]
     if(ds_info.name == 'ljspeech'):

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -21,7 +21,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from random import randint
-  
+import IPython
+from scipy.io.wavfile import write
+import numpy as np  
 
 from absl import logging
 
@@ -129,16 +131,6 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
 
   # if not image item instances 
   if not image_key:
-    ##Check if instance of audio item 
-    audio_keys = [
-    k for k, feature in ds_info.features.items()
-    if isinstance(feature,features_lib.Audio)]
-   
-#     if not audio_keys: 
-#       raise ValueError(
-#         "Visualisation not supported for dataset `{}`. Was not able to "
-#         "auto-infer the audio.".format(ds_info.name))
-
     audio_samples=[]
     if(ds_info.name == 'ljspeech'):
       key = 'speech'

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -83,37 +83,37 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
         if isinstance(feature,features_lib.Audio)]
         print(audio_keys)
         
-          audio_samples=[]
-          if(ds_info.name == 'ljspeech'):
-            key = 'speech'
-          else:
-            key = 'audio'
+        audio_samples=[]
+        if(ds_info.name == 'ljspeech'):
+          key = 'speech'
+        else:
+          key = 'audio'
 
-          samplerate = 16000
-          ctr = 0
-          for features in ds:
-              ctr+=100
-              audio_samples.append(features[key].numpy())
-          to_gen=[]
-          for _ in range(2):
-            value = randint(0, len(audio_samples))
-            to_gen.append(audio_samples[value])
-          ctr=0
-          for audio in to_gen:
-            ctr+=1
-            name = '/content/audio' + str(ctr) + '.wav'
-            write(name,samplerate,audio)
-            IPython.display.display(IPython.display.Audio(name)) 
-            print(name)
+        samplerate = 16000
+        ctr = 0
+        for features in ds:
+            ctr+=100
+            audio_samples.append(features[key].numpy())
+        to_gen=[]
+        for _ in range(2):
+          value = randint(0, len(audio_samples))
+          to_gen.append(audio_samples[value])
+        ctr=0
+        for audio in to_gen:
+          ctr+=1
+          name = '/content/audio' + str(ctr) + '.wav'
+          write(name,samplerate,audio)
+          IPython.display.display(IPython.display.Audio(name)) 
+          print(name)
 
-          fig,a =  plt.subplots(2,2)
+        fig,a =  plt.subplots(2,2)
 
-          a[0][0].plot(to_gen[0])
-          a[0][1].plot(to_gen[1])
-          a[1][0].plot(to_gen[0])
-          a[1][1].plot(to_gen[1])
+        a[0][0].plot(to_gen[0])
+        a[0][1].plot(to_gen[1])
+        a[1][0].plot(to_gen[0])
+        a[1][1].plot(to_gen[1])
 
-          return fig
+        return fig
 
 
     if not audio_keys: 

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -21,8 +21,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from random import randint
-import pydub
-from pydub import AudioSegment
 import IPython
 from scipy.io.wavfile import write
 import numpy as np  
@@ -146,18 +144,14 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     for _ in range(4):
       value = randint(0, len(audio_samples))
       to_gen.append(audio_samples[value])
-    
+        
     t1 = 0
-    t2 = 20 * 1000 # taking only uptill the first 20 ms of the audio 
-    
+    t2 = 100 * 1000
     for audio in to_gen:
       name = '/content/audio.wav'
-      write(name,samplerate,audio)
-      newAudio = AudioSegment.from_wav(name)
-      newAudio = newAudio[t1:t2]
-      newAudio.export('trimmed_audio.wav', format="wav") 
-      IPython.display.display(IPython.display.Audio('trimmed_audio.wav')) 
-
+      newAudio = audio[t1:t2]
+      write(name,samplerate,newAudio)
+      IPython.display.display(IPython.display.Audio(name)) 
 
     fig,a =  plt.subplots(2,2)
 

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -68,11 +68,11 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
   plt = lazy_imports_lib.lazy_imports.matplotlib.pyplot
 
   if not image_key:
-    # Infer the image and label keys
-#     image_keys = [
-#         k for k, feature in ds_info.features.items()
-#         if isinstance(feature, features_lib.Image)
-#         ]
+#    Infer the image and label keys
+    image_keys = [
+        k for k, feature in ds_info.features.items()
+        if isinstance(feature, features_lib.Image)
+        ]
 #         if len(image_keys) > 1:
 #         raise ValueError(
 #             "Multiple image features detected in the dataset. Using the first one. You can "

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -82,44 +82,46 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
         k for k, feature in ds_info.features.items()
         if isinstance(feature,features_lib.Audio)]
         print(audio_keys)
+        
+          audio_samples=[]
+          if(ds_info.name == 'ljspeech'):
+            key = 'speech'
+          else:
+            key = 'audio'
+
+          samplerate = 16000
+          ctr = 0
+          for features in ds:
+              ctr+=100
+              audio_samples.append(features[key].numpy())
+          to_gen=[]
+          for _ in range(2):
+            value = randint(0, len(audio_samples))
+            to_gen.append(audio_samples[value])
+          ctr=0
+          for audio in to_gen:
+            ctr+=1
+            name = '/content/audio' + str(ctr) + '.wav'
+            write(name,samplerate,audio)
+            IPython.display.display(IPython.display.Audio(name)) 
+            print(name)
+
+          fig,a =  plt.subplots(2,2)
+
+          a[0][0].plot(to_gen[0])
+          a[0][1].plot(to_gen[1])
+          a[1][0].plot(to_gen[0])
+          a[1][1].plot(to_gen[1])
+
+          return fig
+
 
     if not audio_keys: 
       raise ValueError(
           "Visualisation not supported for dataset `{}`. Was not able to "
           "auto-infer image.".format(ds_info.name)
    
-  if len(audio_keys) > 1:
-      audio_samples=[]
-      if(ds_info.name == 'ljspeech'):
-        key = 'speech'
-      else:
-        key = 'audio'
-
-      samplerate = 16000
-      ctr = 0
-      for features in ds:
-          ctr+=100
-          audio_samples.append(features[key].numpy())
-      to_gen=[]
-      for _ in range(2):
-        value = randint(0, len(audio_samples))
-        to_gen.append(audio_samples[value])
-      ctr=0
-      for audio in to_gen:
-        ctr+=1
-        name = '/content/audio' + str(ctr) + '.wav'
-        write(name,samplerate,audio)
-        IPython.display.display(IPython.display.Audio(name)) 
-        print(name)
-
-      fig,a =  plt.subplots(2,2)
-
-      a[0][0].plot(to_gen[0])
-      a[0][1].plot(to_gen[1])
-      a[1][0].plot(to_gen[0])
-      a[1][1].plot(to_gen[1])
-
-      return fig
+    
         
   ## IMAGE VISUALIZATION 
   if len(image_keys) > 1:

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -74,8 +74,8 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
 
     if not image_keys:
        audio_keys = [
-        k for k, feature in ds_info.features.items()]
-        if isinstance(feature,features_lib.audio)
+        k for k, feature in ds_info.features.items()
+        if isinstance(feature,features_lib.audio)]
 
         if len(audio_keys) > 1:
         raise ValueError("Audio keys generated as {}".format(audio_keys))

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -20,6 +20,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from random import randint
+  
 
 from absl import logging
 
@@ -71,18 +73,20 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
         k for k, feature in ds_info.features.items()
         if isinstance(feature, features_lib.Image)
     ]
+    
+    # If does not have image items - Check for audio items 
 
     if not image_keys:
        audio_keys = [
         k for k, feature in ds_info.features.items()
-        if isinstance(feature,features_lib.audio)]
+        if isinstance(feature,features_lib.Audio)]
 
 
-        if not audio keys : 
-          raise ValueError(
-              "Visualisation not supported for dataset `{}`. Was not able to "
-              "auto-infer image.".format(ds_info.name))
- 
+    if not audio_keys: 
+      raise ValueError(
+          "Visualisation not supported for dataset `{}`. Was not able to "
+          "auto-infer image.".format(ds_info.name))
+
    
     if len(audio_keys) > 1:
         raise ValueError("Audio keys generated as {}".format(audio_keys))

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -69,61 +69,61 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
 
   if not image_key:
     # Infer the image and label keys
-    image_keys = [
-        k for k, feature in ds_info.features.items()
-        if isinstance(feature, features_lib.Image)
-        ]
-        if len(image_keys) > 1:
-        raise ValueError(
-            "Multiple image features detected in the dataset. Using the first one. You can "
-            "use `image_key` argument to override. Images detected: %s" %
-            (",".join(image_keys)))
+#     image_keys = [
+#         k for k, feature in ds_info.features.items()
+#         if isinstance(feature, features_lib.Image)
+#         ]
+#         if len(image_keys) > 1:
+#         raise ValueError(
+#             "Multiple image features detected in the dataset. Using the first one. You can "
+#             "use `image_key` argument to override. Images detected: %s" %
+#             (",".join(image_keys)))
 
-      image_key = image_keys[0]
+#       image_key = image_keys[0]
 
-      label_keys = [
-          k for k, feature in ds_info.features.items()
-          if isinstance(feature, features_lib.ClassLabel)
-      ]
+#       label_keys = [
+#           k for k, feature in ds_info.features.items()
+#           if isinstance(feature, features_lib.ClassLabel)
+#       ]
 
-      label_key = label_keys[0] if len(label_keys) == 1 else None
-      if not label_key:
-        logging.info("Was not able to auto-infer label.")
+#       label_key = label_keys[0] if len(label_keys) == 1 else None
+#       if not label_key:
+#         logging.info("Was not able to auto-infer label.")
 
-      num_examples = rows * cols
-      examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
+#       num_examples = rows * cols
+#       examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
 
-      fig = plt.figure(figsize=(plot_scale*cols, plot_scale*rows))
-      fig.subplots_adjust(hspace=1/plot_scale, wspace=1/plot_scale)
-      for i, ex in enumerate(examples):
-        if not isinstance(ex, dict):
-          raise ValueError(
-              "tfds.show_examples requires examples as `dict`, with the same "
-              "structure as `ds_info.features`. It is currently not compatible "
-              "with `as_supervised=True`. Received: {}".format(type(ex)))
-        ax = fig.add_subplot(rows, cols, i+1)
+#       fig = plt.figure(figsize=(plot_scale*cols, plot_scale*rows))
+#       fig.subplots_adjust(hspace=1/plot_scale, wspace=1/plot_scale)
+#       for i, ex in enumerate(examples):
+#         if not isinstance(ex, dict):
+#           raise ValueError(
+#               "tfds.show_examples requires examples as `dict`, with the same "
+#               "structure as `ds_info.features`. It is currently not compatible "
+#               "with `as_supervised=True`. Received: {}".format(type(ex)))
+#         ax = fig.add_subplot(rows, cols, i+1)
 
-        # Plot the image
-        image = ex[image_key]
-        if len(image.shape) != 3:
-          raise ValueError(
-              "Image dimension should be 3. tfds.show_examples does not support "
-              "batched examples or video.")
-        _, _, c = image.shape
-        if c == 1:
-          image = image.reshape(image.shape[:2])
-        ax.imshow(image, cmap="gray")
-        ax.grid(False)
-        plt.xticks([], [])
-        plt.yticks([], [])
+#         # Plot the image
+#         image = ex[image_key]
+#         if len(image.shape) != 3:
+#           raise ValueError(
+#               "Image dimension should be 3. tfds.show_examples does not support "
+#               "batched examples or video.")
+#         _, _, c = image.shape
+#         if c == 1:
+#           image = image.reshape(image.shape[:2])
+#         ax.imshow(image, cmap="gray")
+#         ax.grid(False)
+#         plt.xticks([], [])
+#         plt.yticks([], [])
 
-        # Plot the label
-        if label_key:
-          label = ex[label_key]
-          label_str = ds_info.features[label_key].int2str(label)
-          plt.xlabel("{} ({})".format(label_str, label))
-      plt.show()
-      return fig
+#         # Plot the label
+#         if label_key:
+#           label = ex[label_key]
+#           label_str = ds_info.features[label_key].int2str(label)
+#           plt.xlabel("{} ({})".format(label_str, label))
+#       plt.show()
+#       return fig
     # If does not have image items - Check for audio items 
 
     if not image_keys:

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -77,16 +77,16 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     # If does not have image items - Check for audio items 
 
     if not image_keys:
-       audio_keys = [
+        print(features_lib.Audio)
+        audio_keys = [
         k for k, feature in ds_info.features.items()
         if isinstance(feature,features_lib.Audio)]
-
+        print(audio_keys)
 
     if not audio_keys: 
       raise ValueError(
           "Visualisation not supported for dataset `{}`. Was not able to "
-          "auto-infer image.".format(ds_info.name))
-
+          "auto-infer image.".format(ds_info.name)
    
     if len(audio_keys) > 1:
         raise ValueError("Audio keys generated as {}".format(audio_keys))

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -88,8 +88,8 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
           "Visualisation not supported for dataset `{}`. Was not able to "
           "auto-infer image.".format(ds_info.name)
    
-    if len(audio_keys) > 1:
-        raise ValueError("Audio keys generated as {}".format(audio_keys))
+#     if len(audio_keys) > 1:
+#         raise ValueError("Audio keys generated as {}".format(audio_keys))
 
           
           

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -80,9 +80,9 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
       if isinstance(feature,features_lib.Audio)]
 
       if not audio_keys: 
-      raise ValueError(
-        "Visualisation not supported for dataset `{}`. Was not able to "
-        "auto-infer the audio.".format(ds_info.name)
+        raise ValueError(
+          "Visualisation not supported for dataset `{}`. Was not able to "
+          "auto-infer the audio.".format(ds_info.name)
 
       audio_samples=[]
       if(ds_info.name == 'ljspeech'):

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from random import randint
+from pydub import AudioSegment
 import IPython
 from scipy.io.wavfile import write
 import numpy as np  
@@ -141,23 +142,28 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     for features in ds:
         audio_samples.append(features[key].numpy())
     to_gen=[]
-    for _ in range(2):
+    for _ in range(4):
       value = randint(0, len(audio_samples))
       to_gen.append(audio_samples[value])
-    ctr=0
+    
+    t1 = 0
+    t2 = 20 * 1000 # taking only uptill the first 20 ms of the audio 
+    
     for audio in to_gen:
-      ctr+=1
-      name = '/content/audio' + str(ctr) + '.wav'
+      name = '/content/audio.wav'
       write(name,samplerate,audio)
-      IPython.display.display(IPython.display.Audio(name)) 
-      print(name)
+      newAudio = AudioSegment.from_wav(name)
+      newAudio = newAudio[t1:t2]
+      newAudio.export('trimmed_audio.wav', format="wav") 
+      IPython.display.display(IPython.display.Audio('trimmed_audio.wav')) 
+
 
     fig,a =  plt.subplots(2,2)
 
     a[0][0].plot(to_gen[0])
     a[0][1].plot(to_gen[1])
-    a[1][0].plot(to_gen[0])
-    a[1][1].plot(to_gen[1])
+    a[1][0].plot(to_gen[2])
+    a[1][1].plot(to_gen[3])
     plt.show()
 
     return fig

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -77,13 +77,15 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
         k for k, feature in ds_info.features.items()
         if isinstance(feature,features_lib.audio)]
 
-        if len(audio_keys) > 1:
-        raise ValueError("Audio keys generated as {}".format(audio_keys))
 
         if not audio keys : 
           raise ValueError(
               "Visualisation not supported for dataset `{}`. Was not able to "
               "auto-infer image.".format(ds_info.name))
+ 
+   
+    if len(audio_keys) > 1:
+        raise ValueError("Audio keys generated as {}".format(audio_keys))
 
           
           

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from random import randint
+import pydub
 from pydub import AudioSegment
 import IPython
 from scipy.io.wavfile import write

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -73,10 +73,22 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     ]
 
     if not image_keys:
-      raise ValueError(
-          "Visualisation not supported for dataset `{}`. Was not able to "
-          "auto-infer image.".format(ds_info.name))
+       audio_keys = [
+        k for k, feature in ds_info.features.items()]
+        if isinstance(feature,features_lib.audio)
 
+        if len(audio_keys) > 1:
+        raise ValueError("Audio keys generated as {}".format(audio_keys))
+
+        if not audio keys : 
+          raise ValueError(
+              "Visualisation not supported for dataset `{}`. Was not able to "
+              "auto-infer image.".format(ds_info.name))
+
+          
+          
+
+    ## IMAGE VISUALIZATION 
     if len(image_keys) > 1:
       raise ValueError(
           "Multiple image features detected in the dataset. Using the first one. You can "

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -72,8 +72,58 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
     image_keys = [
         k for k, feature in ds_info.features.items()
         if isinstance(feature, features_lib.Image)
-    ]
-    
+        ]
+        if len(image_keys) > 1:
+        raise ValueError(
+            "Multiple image features detected in the dataset. Using the first one. You can "
+            "use `image_key` argument to override. Images detected: %s" %
+            (",".join(image_keys)))
+
+      image_key = image_keys[0]
+
+      label_keys = [
+          k for k, feature in ds_info.features.items()
+          if isinstance(feature, features_lib.ClassLabel)
+      ]
+
+      label_key = label_keys[0] if len(label_keys) == 1 else None
+      if not label_key:
+        logging.info("Was not able to auto-infer label.")
+
+      num_examples = rows * cols
+      examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
+
+      fig = plt.figure(figsize=(plot_scale*cols, plot_scale*rows))
+      fig.subplots_adjust(hspace=1/plot_scale, wspace=1/plot_scale)
+      for i, ex in enumerate(examples):
+        if not isinstance(ex, dict):
+          raise ValueError(
+              "tfds.show_examples requires examples as `dict`, with the same "
+              "structure as `ds_info.features`. It is currently not compatible "
+              "with `as_supervised=True`. Received: {}".format(type(ex)))
+        ax = fig.add_subplot(rows, cols, i+1)
+
+        # Plot the image
+        image = ex[image_key]
+        if len(image.shape) != 3:
+          raise ValueError(
+              "Image dimension should be 3. tfds.show_examples does not support "
+              "batched examples or video.")
+        _, _, c = image.shape
+        if c == 1:
+          image = image.reshape(image.shape[:2])
+        ax.imshow(image, cmap="gray")
+        ax.grid(False)
+        plt.xticks([], [])
+        plt.yticks([], [])
+
+        # Plot the label
+        if label_key:
+          label = ex[label_key]
+          label_str = ds_info.features[label_key].int2str(label)
+          plt.xlabel("{} ({})".format(label_str, label))
+      plt.show()
+      return fig
     # If does not have image items - Check for audio items 
 
     if not image_keys:
@@ -116,62 +166,12 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
         return fig
 
 
-    if not audio_keys: 
-      raise ValueError(
-          "Visualisation not supported for dataset `{}`. Was not able to "
-          "auto-infer image.".format(ds_info.name)
+#     if not audio_keys: 
+#       raise ValueError(
+#           "Visualisation not supported for dataset `{}`. Was not able to "
+#           "auto-infer image.".format(ds_info.name)
    
     
         
   ## IMAGE VISUALIZATION 
-#   if len(image_keys) > 1:
-#     raise ValueError(
-#         "Multiple image features detected in the dataset. Using the first one. You can "
-#         "use `image_key` argument to override. Images detected: %s" %
-#         (",".join(image_keys)))
 
-  image_key = image_keys[0]
-
-  label_keys = [
-      k for k, feature in ds_info.features.items()
-      if isinstance(feature, features_lib.ClassLabel)
-  ]
-
-  label_key = label_keys[0] if len(label_keys) == 1 else None
-  if not label_key:
-    logging.info("Was not able to auto-infer label.")
-
-  num_examples = rows * cols
-  examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
-        
-  fig = plt.figure(figsize=(plot_scale*cols, plot_scale*rows))
-  fig.subplots_adjust(hspace=1/plot_scale, wspace=1/plot_scale)
-  for i, ex in enumerate(examples):
-    if not isinstance(ex, dict):
-      raise ValueError(
-          "tfds.show_examples requires examples as `dict`, with the same "
-          "structure as `ds_info.features`. It is currently not compatible "
-          "with `as_supervised=True`. Received: {}".format(type(ex)))
-    ax = fig.add_subplot(rows, cols, i+1)
-
-    # Plot the image
-    image = ex[image_key]
-    if len(image.shape) != 3:
-      raise ValueError(
-          "Image dimension should be 3. tfds.show_examples does not support "
-          "batched examples or video.")
-    _, _, c = image.shape
-    if c == 1:
-      image = image.reshape(image.shape[:2])
-    ax.imshow(image, cmap="gray")
-    ax.grid(False)
-    plt.xticks([], [])
-    plt.yticks([], [])
-
-    # Plot the label
-    if label_key:
-      label = ex[label_key]
-      label_str = ds_info.features[label_key].int2str(label)
-      plt.xlabel("{} ({})".format(label_str, label))
-  plt.show()
-  return fig

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -68,59 +68,18 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
   plt = lazy_imports_lib.lazy_imports.matplotlib.pyplot
 
   if not image_key:
-#   Infer the image and label keys
+    #Infer the image and label keys
     image_keys = [
         k for k, feature in ds_info.features.items()
         if isinstance(feature, features_lib.Image)
         ]
-    if not image_key:
-      ##Check if instance of audio item 
-      audio_keys = [
-      k for k, feature in ds_info.features.items()
-      if isinstance(feature,features_lib.Audio)]
-
-      if not audio_keys: 
-        raise ValueError(
-          "Visualisation not supported for dataset `{}`. Was not able to "
-          "auto-infer the audio.".format(ds_info.name))
-
-      audio_samples=[]
-      if(ds_info.name == 'ljspeech'):
-        key = 'speech'
-      else:
-        key = 'audio'
-
-      samplerate = 16000
-      for features in ds:
-          audio_samples.append(features[key].numpy())
-      to_gen=[]
-      for _ in range(2):
-        value = randint(0, len(audio_samples))
-        to_gen.append(audio_samples[value])
-      ctr=0
-      for audio in to_gen:
-        ctr+=1
-        name = '/content/audio' + str(ctr) + '.wav'
-        write(name,samplerate,audio)
-        IPython.display.display(IPython.display.Audio(name)) 
-        print(name)
-
-      fig,a =  plt.subplots(2,2)
-
-      a[0][0].plot(to_gen[0])
-      a[0][1].plot(to_gen[1])
-      a[1][0].plot(to_gen[0])
-      a[1][1].plot(to_gen[1])
-      plt.show()
-
-      return fig
-
-
+  #If image_keys has been populated by image item instances 
+  if image_keys:
     if len(image_keys) > 1:
-    raise ValueError(
-        "Multiple image features detected in the dataset. Using the first one. You can "
-        "use `image_key` argument to override. Images detected: %s" %
-        (",".join(image_keys)))
+      raise ValueError(
+          "Multiple image features detected in the dataset. Using the first one. You can "
+          "use `image_key` argument to override. Images detected: %s" %
+          (",".join(image_keys)))
 
     image_key = image_keys[0]
 
@@ -168,3 +127,47 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
       plt.show()
       return fig
     
+    # if not image item instances 
+    if not image_key:
+      ##Check if instance of audio item 
+      audio_keys = [
+      k for k, feature in ds_info.features.items()
+      if isinstance(feature,features_lib.Audio)]
+
+      if not audio_keys: 
+        raise ValueError(
+          "Visualisation not supported for dataset `{}`. Was not able to "
+          "auto-infer the audio.".format(ds_info.name))
+
+      audio_samples=[]
+      if(ds_info.name == 'ljspeech'):
+        key = 'speech'
+      else:
+        key = 'audio'
+
+      samplerate = 16000
+      for features in ds:
+          audio_samples.append(features[key].numpy())
+      to_gen=[]
+      for _ in range(2):
+        value = randint(0, len(audio_samples))
+        to_gen.append(audio_samples[value])
+      ctr=0
+      for audio in to_gen:
+        ctr+=1
+        name = '/content/audio' + str(ctr) + '.wav'
+        write(name,samplerate,audio)
+        IPython.display.display(IPython.display.Audio(name)) 
+        print(name)
+
+      fig,a =  plt.subplots(2,2)
+
+      a[0][0].plot(to_gen[0])
+      a[0][1].plot(to_gen[1])
+      a[1][0].plot(to_gen[0])
+      a[1][1].plot(to_gen[1])
+      plt.show()
+
+      return fig
+
+   

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -119,55 +119,55 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
       plt.xticks([], [])
       plt.yticks([], [])
 
-        # Plot the label
-        if label_key:
-          label = ex[label_key]
-          label_str = ds_info.features[label_key].int2str(label)
-          plt.xlabel("{} ({})".format(label_str, label))
-      plt.show()
-      return fig
-    
-    # if not image item instances 
-    if not image_key:
-      ##Check if instance of audio item 
-      audio_keys = [
-      k for k, feature in ds_info.features.items()
-      if isinstance(feature,features_lib.Audio)]
+      # Plot the label
+      if label_key:
+        label = ex[label_key]
+        label_str = ds_info.features[label_key].int2str(label)
+        plt.xlabel("{} ({})".format(label_str, label))
+    plt.show()
+    return fig
 
-      if not audio_keys: 
-        raise ValueError(
-          "Visualisation not supported for dataset `{}`. Was not able to "
-          "auto-infer the audio.".format(ds_info.name))
+  # if not image item instances 
+  if not image_key:
+    ##Check if instance of audio item 
+    audio_keys = [
+    k for k, feature in ds_info.features.items()
+    if isinstance(feature,features_lib.Audio)]
 
-      audio_samples=[]
-      if(ds_info.name == 'ljspeech'):
-        key = 'speech'
-      else:
-        key = 'audio'
+    if not audio_keys: 
+      raise ValueError(
+        "Visualisation not supported for dataset `{}`. Was not able to "
+        "auto-infer the audio.".format(ds_info.name))
 
-      samplerate = 16000
-      for features in ds:
-          audio_samples.append(features[key].numpy())
-      to_gen=[]
-      for _ in range(2):
-        value = randint(0, len(audio_samples))
-        to_gen.append(audio_samples[value])
-      ctr=0
-      for audio in to_gen:
-        ctr+=1
-        name = '/content/audio' + str(ctr) + '.wav'
-        write(name,samplerate,audio)
-        IPython.display.display(IPython.display.Audio(name)) 
-        print(name)
+    audio_samples=[]
+    if(ds_info.name == 'ljspeech'):
+      key = 'speech'
+    else:
+      key = 'audio'
 
-      fig,a =  plt.subplots(2,2)
+    samplerate = 16000
+    for features in ds:
+        audio_samples.append(features[key].numpy())
+    to_gen=[]
+    for _ in range(2):
+      value = randint(0, len(audio_samples))
+      to_gen.append(audio_samples[value])
+    ctr=0
+    for audio in to_gen:
+      ctr+=1
+      name = '/content/audio' + str(ctr) + '.wav'
+      write(name,samplerate,audio)
+      IPython.display.display(IPython.display.Audio(name)) 
+      print(name)
 
-      a[0][0].plot(to_gen[0])
-      a[0][1].plot(to_gen[1])
-      a[1][0].plot(to_gen[0])
-      a[1][1].plot(to_gen[1])
-      plt.show()
+    fig,a =  plt.subplots(2,2)
 
-      return fig
+    a[0][0].plot(to_gen[0])
+    a[0][1].plot(to_gen[1])
+    a[1][0].plot(to_gen[0])
+    a[1][1].plot(to_gen[1])
+    plt.show()
+
+    return fig
 
    

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -88,20 +88,47 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
           "Visualisation not supported for dataset `{}`. Was not able to "
           "auto-infer image.".format(ds_info.name)
    
-#     if len(audio_keys) > 1:
-#         raise ValueError("Audio keys generated as {}".format(audio_keys))
+  if len(audio_keys) > 1:
+      audio_samples=[]
+      if(ds_info.name == 'ljspeech'):
+        key = 'speech'
+      else:
+        key = 'audio'
 
-          
-          
+      samplerate = 16000
+      ctr = 0
+      for features in ds:
+          ctr+=100
+          audio_samples.append(features[key].numpy())
+      to_gen=[]
+      for _ in range(2):
+        value = randint(0, len(audio_samples))
+        to_gen.append(audio_samples[value])
+      ctr=0
+      for audio in to_gen:
+        ctr+=1
+        name = '/content/audio' + str(ctr) + '.wav'
+        write(name,samplerate,audio)
+        IPython.display.display(IPython.display.Audio(name)) 
+        print(name)
 
-    ## IMAGE VISUALIZATION 
-    if len(image_keys) > 1:
-      raise ValueError(
-          "Multiple image features detected in the dataset. Using the first one. You can "
-          "use `image_key` argument to override. Images detected: %s" %
-          (",".join(image_keys)))
+      fig,a =  plt.subplots(2,2)
 
-    image_key = image_keys[0]
+      a[0][0].plot(to_gen[0])
+      a[0][1].plot(to_gen[1])
+      a[1][0].plot(to_gen[0])
+      a[1][1].plot(to_gen[1])
+
+      return fig
+        
+  ## IMAGE VISUALIZATION 
+  if len(image_keys) > 1:
+    raise ValueError(
+        "Multiple image features detected in the dataset. Using the first one. You can "
+        "use `image_key` argument to override. Images detected: %s" %
+        (",".join(image_keys)))
+
+  image_key = image_keys[0]
 
   label_keys = [
       k for k, feature in ds_info.features.items()
@@ -114,7 +141,7 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
 
   num_examples = rows * cols
   examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
-
+        
   fig = plt.figure(figsize=(plot_scale*cols, plot_scale*rows))
   fig.subplots_adjust(hspace=1/plot_scale, wspace=1/plot_scale)
   for i, ex in enumerate(examples):

--- a/tensorflow_datasets/core/visualization.py
+++ b/tensorflow_datasets/core/visualization.py
@@ -82,7 +82,7 @@ def show_examples(ds_info, ds, rows=3, cols=3, plot_scale=3., image_key=None):
       if not audio_keys: 
         raise ValueError(
           "Visualisation not supported for dataset `{}`. Was not able to "
-          "auto-infer the audio.".format(ds_info.name)
+          "auto-infer the audio.".format(ds_info.name))
 
       audio_samples=[]
       if(ds_info.name == 'ljspeech'):


### PR DESCRIPTION
Added partial visualization support for audio datasets under tfds: Tested on LJspeech, Groove
Issue Link: [1528](https://github.com/tensorflow/datasets/issues/1528)

Procedure:
1. Pick random samples from argument dataset 
2. Trim the picked audio samples to include only the first 6 seconds of the audio 
3. Use IPython to display the trimmed audio sample 
4. Plot the corresponding audio waveforms. 

Notebook demonstration: [Link](https://colab.research.google.com/drive/11NSYCRPiHsDCQZBxDVew-OniGbscdwxH)
