### PR TITLE
TFDS fails on older versions

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -287,7 +287,7 @@ class DatasetBuilder(object):
       return
 
     if self.version.tfds_version_to_prepare:
-      available_to_prepare = ", ".join(str(v) for v in [self.canonical_version] + [max(self.versions)]
+      available_to_prepare = ", ".join(str(v) for v in self.versions
                                        if not v.tfds_version_to_prepare)
       raise AssertionError(
           "The version of the dataset you are trying to use ({}:{}) can only "
@@ -298,6 +298,27 @@ class DatasetBuilder(object):
               self.name, self.version, self.version.tfds_version_to_prepare,
               available_to_prepare))
 
+    # Check if requested version is canonical version or max(self.versions)
+    # if not raises error as tfds not supports older versions of datasets.
+    new_versions = [str(v) for v in [self.canonical_version] + [max(self.versions)]]
+    if str(self._version) not in new_versions:
+      # if canonical and maximum versions are same then sugeest only one version
+      if max(self.versions) != self.canonical_version:
+        raise AssertionError(
+            "The version of the dataset you are trying to use ({}:{}) cannot"
+            " be generated as this version is too older version to use. Please "
+            " use another new availble version of the dataset"
+            " (available for `download_and_prepare`: "
+            "{}).".format(
+                self.name, self.version, new_versions))
+      else:
+        raise AssertionError(
+            "The version of the dataset you are trying to use ({}:{}) cannot"
+            " be generated as this version is too older version to use. Please "
+            " use another new availble version of the dataset"
+            " (available for `download_and_prepare`: "
+            "{}).".format(
+                self.name, self.version, new_versions[0]))
     # Currently it's not possible to overwrite the data because it would
     # conflict with versioning: If the last version has already been generated,
     # it will always be reloaded and data_dir will be set at construction.

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -287,7 +287,7 @@ class DatasetBuilder(object):
       return
 
     if self.version.tfds_version_to_prepare:
-      available_to_prepare = ", ".join(str(v) for v in self.versions
+      available_to_prepare = ", ".join(str(v) for v in [self.canonical_version] + [max(self.versions)]
                                        if not v.tfds_version_to_prepare)
       raise AssertionError(
           "The version of the dataset you are trying to use ({}:{}) can only "

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -286,39 +286,19 @@ class DatasetBuilder(object):
       logging.info("Reusing dataset %s (%s)", self.name, self._data_dir)
       return
 
-    if self.version.tfds_version_to_prepare:
-      available_to_prepare = ", ".join(str(v) for v in self.versions
-                                       if not v.tfds_version_to_prepare)
-      raise AssertionError(
-          "The version of the dataset you are trying to use ({}:{}) can only "
-          "be generated using TFDS code synced @ {} or earlier. Either sync to "
-          "that version of TFDS to first prepare the data or use another "
-          "version of the dataset (available for `download_and_prepare`: "
-          "{}).".format(
-              self.name, self.version, self.version.tfds_version_to_prepare,
-              available_to_prepare))
-
     # Check if requested version is canonical version or max(self.versions)
+    # Also check for tfds_version_to_prepare.
     # if not raises error as tfds not supports older versions of datasets.
-    new_versions = [str(v) for v in [self.canonical_version] + [max(self.versions)]]
-    if str(self._version) not in new_versions:
-      # if canonical and maximum versions are same then suggest only one version
-      if max(self.versions) != self.canonical_version:
-        raise AssertionError(
-            "The version of the dataset you are trying to use ({}:{}) cannot"
-            " be generated as this version is too older version to use. Please "
-            " use another new availble version of the dataset"
-            " (available for `download_and_prepare`: "
-            "{}).".format(
-                self.name, self.version, new_versions))
-      else:
-        raise AssertionError(
-            "The version of the dataset you are trying to use ({}:{}) cannot"
-            " be generated as this version is too older version to use. Please "
-            " use another new availble version of the dataset"
-            " (available for `download_and_prepare`: "
-            "{}).".format(
-                self.name, self.version, new_versions[0]))
+    new_versions = set(str(v) for v in [self.canonical_version] + [max(self.versions)]
+                        if not v.tfds_version_to_prepare)
+    msg = ("The version of the dataset you are trying to use ({}:{}) cannot"
+           " be generated as this version is too older version to use. Please"
+           " use another new availble version of the dataset"
+           " (available for `download_and_prepare`:{}).")
+    if (str(self._version) not in new_versions) or (self.version.tfds_version_to_prepare):
+      raise AssertionError(msg.format(
+           self.name, self.version, new_versions))
+      
     # Currently it's not possible to overwrite the data because it would
     # conflict with versioning: If the last version has already been generated,
     # it will always be reloaded and data_dir will be set at construction.

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -302,7 +302,7 @@ class DatasetBuilder(object):
     # if not raises error as tfds not supports older versions of datasets.
     new_versions = [str(v) for v in [self.canonical_version] + [max(self.versions)]]
     if str(self._version) not in new_versions:
-      # if canonical and maximum versions are same then sugeest only one version
+      # if canonical and maximum versions are same then suggest only one version
       if max(self.versions) != self.canonical_version:
         raise AssertionError(
             "The version of the dataset you are trying to use ({}:{}) cannot"

--- a/tensorflow_datasets/core/dataset_builder_test.py
+++ b/tensorflow_datasets/core/dataset_builder_test.py
@@ -324,6 +324,18 @@ class DatasetBuilderTest(testing.TestCase):
     self.assertIsNotNone(builder)
     with self.assertRaisesWithPredicateMatch(AssertionError, expected):
       builder.download_and_prepare()
+      
+  def test_with_old_versions(self):
+    expected = (
+        "The version of the dataset you are trying to use"
+        " (dummy_dataset_shared_generator:0.0.8) cannot be"
+        " generated as this version is too older to use."
+        " Please  use another new availble version of the dataset"
+        " (new availble version: ['1.0.0', '2.0.0'])")
+    builder = DummyDatasetSharedGenerator(version="0.0.8")
+    self.assertIsNotNone(builder)
+    with self.assertRaisesWithPredicateMatch(AssertionError, expected):
+      builder.download_and_prepare()
 
   def test_invalid_split_dataset(self):
     with testing.tmp_dir(self.get_temp_dir()) as tmp_dir:

--- a/tensorflow_datasets/core/dataset_builder_test.py
+++ b/tensorflow_datasets/core/dataset_builder_test.py
@@ -315,11 +315,11 @@ class DatasetBuilderTest(testing.TestCase):
 
   def test_non_preparable_version(self, *unused_mocks):
     expected = (
-        "The version of the dataset you are trying to use ("
-        "dummy_dataset_shared_generator:0.0.7) can only be generated using TFDS"
-        " code synced @ v1.0.0 or earlier. Either sync to that version of TFDS "
-        "to first prepare the data or use another version of the dataset "
-        "(available for `download_and_prepare`: 1.0.0, 2.0.0, 0.0.9, 0.0.8).")
+        "The version of the dataset you are trying to use"
+        " (dummy_dataset_shared_generator:0.0.7) cannot be"
+        " generated as this version is too older version to use."
+        " Please use another new availble version of the dataset"
+        " (available for `download_and_prepare`:{'2.0.0', '1.0.0'}).")
     builder = DummyDatasetSharedGenerator(version="0.0.7")
     self.assertIsNotNone(builder)
     with self.assertRaisesWithPredicateMatch(AssertionError, expected):
@@ -328,11 +328,12 @@ class DatasetBuilderTest(testing.TestCase):
   def test_with_old_versions(self):
     expected = (
         "The version of the dataset you are trying to use"
-        " (dummy_dataset_shared_generator:0.0.8) cannot be"
-        " generated as this version is too older to use."
-        " Please  use another new availble version of the dataset"
-        " (new availble version: ['1.0.0', '2.0.0'])")
-    builder = DummyDatasetSharedGenerator(version="0.0.8")
+        " (dummy_mnist:0.0.8) cannot be generated as this"
+        " version is too older version to use. Please use"
+        " another new availble version of the dataset"
+        " (available for `download_and_prepare`:{'2.0.0', '1.0.0'}).")
+    with testing.tmp_dir(self.get_temp_dir()) as tmp_dir:
+      builder = testing.DummyMnist(version="0.0.8",data_dir=tmp_dir)
     self.assertIsNotNone(builder)
     with self.assertRaisesWithPredicateMatch(AssertionError, expected):
       builder.download_and_prepare()

--- a/tensorflow_datasets/testing/test_utils.py
+++ b/tensorflow_datasets/testing/test_utils.py
@@ -394,6 +394,10 @@ class DummyMnist(dataset_builder.GeneratorBasedBuilder):
   """Test DatasetBuilder."""
 
   VERSION = utils.Version("1.0.0")
+  SUPPORTED_VERSIONS = [
+      "2.0.0",
+      "0.0.8",
+  ]
 
   def _info(self):
     return dataset_info.DatasetInfo(

--- a/tensorflow_datasets/testing/test_utils.py
+++ b/tensorflow_datasets/testing/test_utils.py
@@ -395,8 +395,8 @@ class DummyMnist(dataset_builder.GeneratorBasedBuilder):
 
   VERSION = utils.Version("1.0.0")
   SUPPORTED_VERSIONS = [
-      "2.0.0",
-      "0.0.8",
+      utils.Version("2.0.0"),
+      utils.Version("0.0.8"),
   ]
 
   def _info(self):


### PR DESCRIPTION
Fixes #1708 
@Conchylicultor  please have a look. when I run dataset_builder_test.py it shows me error 

> Traceback (most recent call last):
  File "dataset_builder_test.py", line 323, in test_non_preparable_version
    builder.download_and_prepare()
  File "C:\Users\eshan\Anaconda3\envs\keras-gpu\lib\contextlib.py", line 99, in __exit__
    self.gen.throw(type, value, traceback)
  File "C:\Users\eshan\Anaconda3\envs\keras-gpu\lib\site-packages\tensorflow_core\python\framework\test_util.py", line 2755, in assertRaisesWithPredicateMatch
    (str(type(e)), str(e)))
AssertionError: Exception of type <class 'AssertionError'>: The version of the dataset you are trying to use (dummy_dataset_shared_generator:0.0.7) can only be generated using TFDS code synced @ v1.0.0 or earlier. Either sync to that version of TFDS to first prepare the data or use another version of the dataset (available for `download_and_prepare`: 1.0.0, 2.0.0).

This is because version 0.0.7 is not canonical nor maximum version for dummy_dataset_shared_generator