### PR TITLE
Update tfrecords_reader.py

### DIFF
--- a/tensorflow_datasets/core/tfrecords_reader.py
+++ b/tensorflow_datasets/core/tfrecords_reader.py
@@ -423,27 +423,28 @@ class ReadInstruction(object):
   ```
   # The following lines are equivalent:
   ds = tfds.load('mnist', split='test[:33%]')
-  ds = tfds.load('mnist', split=ReadInstruction.from_spec('test[:33%]'))
-  ds = tfds.load('mnist', split=ReadInstruction('test', to=33, unit='%'))
-  ds = tfds.load('mnist', split=ReadInstruction(
+  ds = tfds.load('mnist', split=tfds.core.ReadInstruction.from_spec('test[:33%]'))
+  ds = tfds.load('mnist', split=tfds.core.ReadInstruction('test', to=33, unit='%'))
+  ds = tfds.load('mnist', split=tfds.core.ReadInstruction(
       'test', from_=0, to=33, unit='%'))
 
   # The following lines are equivalent:
   ds = tfds.load('mnist', split='test[:33%]+train[1:-1]')
-  ds = tfds.load('mnist', split=ReadInstruction.from_spec(
+  ds = tfds.load('mnist', split=tfds.core.ReadInstruction.from_spec(
       'test[:33%]+train[1:-1]'))
   ds = tfds.load('mnist', split=(
-      ReadInstruction.('test', to=33, unit='%') +
-      ReadInstruction.('train', from_=1, to=-1, unit='abs')))
+      tfds.core.ReadInstruction.('test', to=33, unit='%') +
+      tfds.core.ReadInstruction.('train', from_=1, to=-1, unit='abs')))
 
   # 10-fold validation:
   tests = tfds.load(
       'mnist',
-      [ReadInstruction('train', from_=k, to=k+10, unit='%')
+      [tfds.core.ReadInstruction('train', from_=k, to=k+10, unit='%')
        for k in range(0, 100, 10)])
   trains = tfds.load(
       'mnist',
-      [RI('train', to=k, unit='%') + RI('train', from_=k+10, unit='%')
+      [tfds.core.ReadInstruction('train', to=k, unit='%') +
+       tfds.core.ReadInstruction('train', from_=k+10, unit='%')
        for k in range(0, 100, 10)])
   ```
 

--- a/tensorflow_datasets/core/tfrecords_reader.py
+++ b/tensorflow_datasets/core/tfrecords_reader.py
@@ -463,7 +463,7 @@ class ReadInstruction(object):
 
   @api_utils.disallow_positional_args(allowed=['split_name'])
   def __init__(self, split_name, rounding='closest', from_=None, to=None,
-               unit=None):
+               unit="%"):
     """Initialize ReadInstruction.
 
     Args:


### PR DESCRIPTION
**Short description**
Loading dataset using [ReadInstruction](https://www.tensorflow.org/datasets/api_docs/python/tfds/core/ReadInstruction) API as described [here ](https://www.tensorflow.org/datasets/splits) gives error.

**Reproduction instructions**

Look on this [colab ](https://colab.research.google.com/drive/1IxOvSSKClmHZWIaQC6oAFmdXA4-SOQ-4)notebook

**Expected behavior**
`tfds.load()` works properly using `ReadInstruction` API

**Purposed Solution**
1. We can update `tfrecords_reader.py` [here](https://github.com/tensorflow/datasets/blob/v2.1.0/tensorflow_datasets/core/tfrecords_reader.py#L465)
2. Also can update [docs](https://github.com/tensorflow/datasets/blob/master/docs/splits.md).

I am updating `tfrecords_reader.py` as user have to define split equals to something whenever he want to use `ReadInstruction` API.
