### PR TITLE
Fix sun split file paths

### DIFF
--- a/tensorflow_datasets/image_classification/sun.py
+++ b/tensorflow_datasets/image_classification/sun.py
@@ -205,7 +205,7 @@ class Sun397(tfds.core.GeneratorBasedBuilder):
       }
       for split, filename in tfds_split_files.items():
         tfds_split_files[split] = tfds.core.get_tfds_path(
-            os.path.join("image", filename))
+            os.path.join("image_classification", filename))
     self._tfds_split_files = tfds_split_files
 
   def _info(self):


### PR DESCRIPTION
Fix  #1709
`sun397_tfds_tr.txt` and other files are located in the `image_classification` folder.