### PR TITLE
Added the command line to implement a new dataset to resolve #1757

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ import tensorflow_datasets as tfds
 import tensorflow as tf
 
 # Here we assume Eager mode is enabled (TF2), but tfds also works in Graph mode.
+#If implementing a data set for the first time, use the below command line.
+# python -m tensorflow_datasets.scripts.download_and_prepare --registrer_checksums=True --datasets='dataset_name'
 
 # Construct a tf.data.Dataset
 ds_train = tfds.load('mnist', split='train', shuffle_files=True)


### PR DESCRIPTION
Most users when implementing a new dataset encountered the below error - 
`NonMatchingChecksumError: Artifact http://pix3d.csail.mit.edu/data/pix3d.zip, downloaded to ./pix3d.csail.mit.edu_pix3d4gh-bf6GMM2oHrBcmQyos_K1PupfuBITgTic9qdZ2Xc.zip.tmp.3b8459f449b34fc68ed246e8c371495f/pix3d.zip, has wrong checksum.`

A comment line containing the resolving command line has been added.
