### PR TITLE
Fixes #1765 - Correction in line no. 177 Colab Notebook 

### DIFF
--- a/docs/overview.ipynb
+++ b/docs/overview.ipynb
@@ -174,7 +174,7 @@
       "source": [
         "## `tfds.load`: A dataset in one line\n",
         "\n",
-        "[`tfds.load`](https://www.tensorflow.org/datasets/api_docs/python/tfds/load) is a convenience method that's the simplest way to build and load a `tf.data.Dataset`.\n",
+        "[`tfds.load`](https://www.tensorflow.org/datasets/api_docs/python/tfds/load) is a convenient method or simplest way to build and load a `tf.data.Dataset`.\n",
         "\n",
         "`tf.data.Dataset` is the standard TensorFlow API to build input pipelines. If you're not familiar with this API, we **strongly** encourage you to read [the official TensorFlow guide](https://www.tensorflow.org/guide/datasets).\n",
         "\n",


### PR DESCRIPTION
A line of code saying `[`tfds.load`](https://www.tensorflow.org/datasets/api_docs/python/tfds/load) is a convenience method that's the simplest way to.` has been corrected to `[`tfds.load`](https://www.tensorflow.org/datasets/api_docs/python/tfds/load) is a convenient method or simplest way to.`
