### PR TITLE
Add support for visualization of video dataset as GIF's 

### DIFF
--- a/tensorflow_datasets/core/lazy_imports_lib.py
+++ b/tensorflow_datasets/core/lazy_imports_lib.py
@@ -50,13 +50,6 @@ class LazyImporter(object):
   @classmethod
   def apache_beam(cls):
     return _try_import("apache_beam")
-  
-  @utils.classproperty
-  @classmethod
-  def moviepy(cls):
-    """For testing purposes only."""
-    _try_import("moviepy.editor")
-    return _try_import("moviepy")
 
   @utils.classproperty
   @classmethod
@@ -88,6 +81,13 @@ class LazyImporter(object):
   def matplotlib(cls):
     _try_import("matplotlib.pyplot")
     return _try_import("matplotlib")
+
+  @utils.classproperty
+  @classmethod
+  def moviepy(cls):
+    """For testing purposes only."""
+    _try_import("moviepy.editor")
+    return _try_import("moviepy")
 
   @utils.classproperty
   @classmethod

--- a/tensorflow_datasets/core/lazy_imports_lib.py
+++ b/tensorflow_datasets/core/lazy_imports_lib.py
@@ -50,6 +50,13 @@ class LazyImporter(object):
   @classmethod
   def apache_beam(cls):
     return _try_import("apache_beam")
+  
+  @utils.classproperty
+  @classmethod
+  def moviepy(cls):
+    """For testing purposes only."""
+    _try_import("moviepy.editor")
+    return _try_import("moviepy")
 
   @utils.classproperty
   @classmethod
@@ -91,6 +98,12 @@ class LazyImporter(object):
   @classmethod
   def nltk(cls):
     return _try_import("nltk")
+
+  @utils.classproperty
+  @classmethod
+  def os(cls):
+    """For testing purposes only."""
+    return _try_import("os")
 
   @utils.classproperty
   @classmethod
@@ -139,12 +152,6 @@ class LazyImporter(object):
   @classmethod
   def tldextract(cls):
     return _try_import("tldextract")
-
-  @utils.classproperty
-  @classmethod
-  def os(cls):
-    """For testing purposes only."""
-    return _try_import("os")
 
   @utils.classproperty
   @classmethod

--- a/tensorflow_datasets/core/visualization/__init__.py
+++ b/tensorflow_datasets/core/visualization/__init__.py
@@ -17,11 +17,13 @@
 
 from tensorflow_datasets.core.visualization.image_visualizer import ImageGridVisualizer
 from tensorflow_datasets.core.visualization.show_examples import show_examples
+from tensorflow_datasets.core.visualization.video_visualizer import VideoGridVisualizer
 from tensorflow_datasets.core.visualization.visualizer import Visualizer
 
 
 __all__ = [
     "ImageGridVisualizer",
     "show_examples",
+    "VideoGridVisualizer",
     "Visualizer",
 ]

--- a/tensorflow_datasets/core/visualization/image_visualizer.py
+++ b/tensorflow_datasets/core/visualization/image_visualizer.py
@@ -69,7 +69,7 @@ def _add_image(ax, image):
   if len(image.shape) != 3:
     raise ValueError(
         'Image dimension should be 3. tfds.show_examples does not support '
-        'batched examples or video.')
+        'batched examples.')
   _, _, c = image.shape
   if c == 1:
     image = image.reshape(image.shape[:2])

--- a/tensorflow_datasets/core/visualization/show_examples.py
+++ b/tensorflow_datasets/core/visualization/show_examples.py
@@ -22,9 +22,11 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_datasets.core.visualization import image_visualizer
+from tensorflow_datasets.core.visualization import video_visualizer
 
 _ALL_VISUALIZERS = [
     image_visualizer.ImageGridVisualizer(),
+    video_visualizer.VideoGridVisualizer(),
 ]
 
 

--- a/tensorflow_datasets/core/visualization/show_examples_test.py
+++ b/tensorflow_datasets/core/visualization/show_examples_test.py
@@ -28,6 +28,7 @@ from tensorflow_datasets.core import visualization
 
 # Import for registration
 from tensorflow_datasets.image_classification import imagenet  # pylint: disable=unused-import,g-bad-import-order
+from tensorflow_datasets.video import moving_mnist
 
 
 class ShowExamplesTest(testing.TestCase):
@@ -37,7 +38,11 @@ class ShowExamplesTest(testing.TestCase):
     with testing.mock_data(num_examples=20):
       ds, ds_info = registered.load(
           'imagenet2012', split='train', with_info=True)
-    visualization.show_examples(ds_info, ds)
+      visualization.show_examples(ds_info, ds)
+
+      ds, ds_info = registered.load(
+            'moving_mnist', split='test', with_info=True)
+      visualization.show_examples(ds_info, ds)
 
   # TODO(tfds): Should add test when there isn't enough examples (ds.take(3))
 

--- a/tensorflow_datasets/core/visualization/video_visualizer.py
+++ b/tensorflow_datasets/core/visualization/video_visualizer.py
@@ -1,0 +1,128 @@
+# coding=utf-8
+# Copyright 2020 The TensorFlow Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Video visualizer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl import logging
+
+from tensorflow_datasets.core import dataset_utils
+from tensorflow_datasets.core import features as features_lib
+from tensorflow_datasets.core import lazy_imports_lib
+from tensorflow_datasets.core.visualization import visualizer
+
+def _make_grid(plot_single_ex_fn, ds, rows, cols, plot_scale):
+
+  plt = lazy_imports_lib.lazy_imports.matplotlib.pyplot
+
+  num_examples = rows * cols
+  examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
+
+  fig = plt.figure(figsize=(plot_scale * cols, plot_scale * rows))
+  fig.subplots_adjust(hspace=1 / plot_scale, wspace=1 / plot_scale)
+
+  for i, ex in enumerate(examples):
+    ax = fig.add_subplot(rows, cols, i+1)
+    plot_single_ex_fn(ax, ex)
+
+  plt.show()
+  return fig
+
+def _add_video(ax, video):
+  """Add the Video to the given `matplotlib.axes.Axes`."""
+  plt = lazy_imports_lib.lazy_imports.matplotlib.pyplot
+
+  if len(video.shape) != 4:
+    raise ValueError(
+        'Video dimension should be 4.')
+  f,_, _, c = video.shape
+  print(video.shape)
+  if c == 1:
+    video = video.reshape(video.shape[:3])
+  for i in range(f):
+    ax.imshow(video[i], cmap='gray')
+    ax.grid(False)
+    plt.xticks([], [])
+    plt.yticks([], [])
+
+class VideoGridVisualizer(visualizer.Visualizer):
+  """Visualizer for video datasets."""
+
+  def match(self, ds_info):
+    """See base class."""
+    # Supervised required a single image key
+    video_keys = visualizer.extract_keys(ds_info.features, features_lib.Video)
+    return len(video_keys) > 0
+
+
+  def show(
+      self,
+      ds_info,
+      ds,
+      rows=3,
+      cols=3,
+      plot_scale=3.,
+      video_key=None,
+  ):
+    """Display the dataset.
+
+    Args:
+      ds_info: `tfds.core.DatasetInfo` object of the dataset to visualize.
+      ds: `tf.data.Dataset`. The tf.data.Dataset object to visualize. Examples
+        should not be batched. Examples will be consumed in order until
+        (rows * cols) are read or the dataset is consumed.
+      rows: `int`, number of rows of the display grid.
+      cols: `int`, number of columns of the display grid.
+      plot_scale: `float`, controls the plot size of the images. Keep this
+        value around 3 to get a good plot. High and low values may cause
+        the labels to get overlapped.
+      video_key: `string`, name of the feature that contains the video. If not
+         set, the system will try to auto-detect it.
+    """
+    # Extract the video key automatically.
+    if not video_key:
+      video_keys = visualizer.extract_keys(ds_info.features, features_lib.Video)
+      video_key = video_keys[0]
+
+    # Optionally extract the label key
+    label_keys = visualizer.extract_keys(
+        ds_info.features, features_lib.ClassLabel)
+    label_key = label_keys[0] if len(label_keys) == 1 else None
+    if not label_key:
+      logging.info('Was not able to auto-infer label.')
+
+    def make_cell_fn(ax, ex):
+      plt = lazy_imports_lib.lazy_imports.matplotlib.pyplot
+
+      if not isinstance(ex, dict):
+        raise ValueError(
+            '{} requires examples as `dict`, with the same '
+            'structure as `ds_info.features`. It is currently not compatible '
+            'with `as_supervised=True`. Received: {}'.format(
+                type(self).__name__, type(ex)))
+
+      _add_video(ax, ex[video_key])
+      if label_key:
+        label = ex[label_key]
+        label_str = ds_info.features[label_key].int2str(label)
+        plt.xlabel('{} ({})'.format(label_str, label))
+
+    # Print the grid
+    fig = _make_grid(make_cell_fn, ds, rows, cols, plot_scale)  
+

--- a/tensorflow_datasets/core/visualization/video_visualizer.py
+++ b/tensorflow_datasets/core/visualization/video_visualizer.py
@@ -40,6 +40,8 @@ def _display_gif(gif_fn, ds, num_examples, width, height):
       should not be batched. Examples will be consumed in order until
       (rows * cols) are read or the dataset is consumed.
     num_examples: Number of examples to display from video dataset.
+    width: width of frame for display GIF.
+    height: height of frame for display GIF.
   """
   examples = list(dataset_utils.as_numpy(ds.take(num_examples)))
   for i, ex in enumerate(examples):
@@ -51,7 +53,11 @@ def _display_gif(gif_fn, ds, num_examples, width, height):
 
 
 def _write_video_gif(video, fps):
-  """Process the Video and write it as GIF."""
+  """Process the Video and write it as GIF.
+  Args:
+    video: numpy array of video as image sequence.
+    fps: frame per second for display GIF. Default to 10.
+  """
   ImageSequenceClip = lazy_imports_lib.lazy_imports.moviepy.editor.ImageSequenceClip
 
   if len(video.shape) != 4:
@@ -98,13 +104,6 @@ class VideoGridVisualizer(visualizer.Visualizer):
       video_keys = visualizer.extract_keys(ds_info.features, features_lib.Video)
       video_key = video_keys[0]
 
-    # Optionally extract the label key
-    label_keys = visualizer.extract_keys(
-        ds_info.features, features_lib.ClassLabel)
-    label_key = label_keys[0] if len(label_keys) == 1 else None
-    if not label_key:
-      logging.info('Was not able to auto-infer label.')
-
     def make_cell_fn(ex):
       if not isinstance(ex, dict):
         raise ValueError(
@@ -114,10 +113,5 @@ class VideoGridVisualizer(visualizer.Visualizer):
                 type(self).__name__, type(ex)))
 
       _write_video_gif(ex[video_key], fps)
-      if label_key:
-        label = ex[label_key]
-        label_str = ds_info.features[label_key].int2str(label)
-        #plt.xlabel('{} ({})'.format(label_str, label))
-
     # Display GIF
-    _display_gif(make_cell_fn, ds, num_examples, width, height)  
+    _display_gif(make_cell_fn, ds, num_examples, width, height)

--- a/tensorflow_datasets/core/visualization/video_visualizer.py
+++ b/tensorflow_datasets/core/visualization/video_visualizer.py
@@ -98,6 +98,9 @@ class VideoGridVisualizer(visualizer.Visualizer):
       num_examples: Number of examples to display from video dataset. Default is 5
       video_key: `string`, name of the feature that contains the video. If not
          set, the system will try to auto-detect it.
+      width: width of frame for display GIF.
+      height: height of frame for display GIF.
+      fps: frame per second for display GIF. Default to 10.
     """
     # Extract the video key automatically.
     if not video_key:


### PR DESCRIPTION
Fixes #1528 @Conchylicultor  please review this PR, I included some extra param for `video_visualizer `for which user can play like fps of GIF's, height & width of frame.

Please see this [colab ](https://colab.research.google.com/drive/1haj7xJl0z8iAzEG93bzM7EYC82WffBYh)notebook show `video_visualizer `in work.