### PR TITLE
Fix to similar bug with horses or humans #1888

### DIFF
--- a/tensorflow_datasets/image_classification/rock_paper_scissors.py
+++ b/tensorflow_datasets/image_classification/rock_paper_scissors.py
@@ -40,7 +40,7 @@ _TEST_URL = "https://storage.googleapis.com/laurencemoroney-blog.appspot.com/rps
 _IMAGE_SIZE = 300
 _IMAGE_SHAPE = (_IMAGE_SIZE, _IMAGE_SIZE, 3)
 
-_NAME_RE = re.compile(r"^(rps|rps-test-set)/(rock|paper|scissors)/[\w-]*\.png$")
+_NAME_RE = re.compile(r"^(rps|rps-test-set)(/|\\)(rock|paper|scissors)(/|\\)[\w-]*\.png$")
 
 
 class RockPaperScissors(tfds.core.GeneratorBasedBuilder):
@@ -93,7 +93,7 @@ class RockPaperScissors(tfds.core.GeneratorBasedBuilder):
       res = _NAME_RE.match(fname)
       if not res:  # if anything other than .png; skip
         continue
-      label = res.group(2).lower()
+      label = res.group(3).lower()
       record = {
           "image": fobj,
           "label": label,


### PR DESCRIPTION
Fix to allow file to be unzipped correctly on Windows

Similar to : https://github.com/tensorflow/datasets/issues/1888


## Description
Fixes bug where regex didn't give correct Windows path syntax, and files weren't unzipped correctly to \Users\ directory.
