### PR TITLE
Disable dataset threading by default

### DIFF
--- a/tensorflow_datasets/core/tfrecords_reader.py
+++ b/tensorflow_datasets/core/tfrecords_reader.py
@@ -59,7 +59,6 @@ def _default_options():
   """Returns optimization options to given dataset."""
   options = tf.data.Options()
   options.experimental_threading.max_intra_op_parallelism = 1
-  options.experimental_threading.private_threadpool_size = 16
   options.experimental_optimization.apply_default_optimizations = True
   options.experimental_optimization.map_fusion = True
   options.experimental_optimization.map_parallelization = True


### PR DESCRIPTION
I am running into out of memory issues when using `tf.distribute` with TensorFlow datasets. Disabling this option fixes the issues for me.

Unfortunately this option cannot be disabled by the user with `experimental_threading.private_threadpool_size=None` since the option expects an integer, or am I missing something?
What is the exact benefit of this option, is it essential for a high performance data pipeline? In my initial testing so far I haven't seen any performance regressions when disabling this option.

I created an TensorFlow issue explaining the memory problems in detail: https://github.com/tensorflow/tensorflow/issues/38617

It would be great if this option could be disabled by default to give users more control over experimental optimizations in the data pipeline.