### PR TITLE
Renaming files on windows fails sometimes

### DIFF
--- a/tensorflow_datasets/core/utils/py_utils.py
+++ b/tensorflow_datasets/core/utils/py_utils.py
@@ -306,7 +306,13 @@ def incomplete_dir(dirname):
   tf.io.gfile.makedirs(tmp_dir)
   try:
     yield tmp_dir
-    tf.io.gfile.rename(tmp_dir, dirname)
+    renamed = False
+    while not renamed:
+        try:
+          tf.io.gfile.rename(tmp_dir, dirname)
+          renamed = True
+        except:
+            pass
   finally:
     if tf.io.gfile.exists(tmp_dir):
       tf.io.gfile.rmtree(tmp_dir)


### PR DESCRIPTION

This bug is not related to `tf.io.gfile.rename` as `os.rename` also fails to rename files.

This bug probably occurs because the `rename` function fails to acquire a `lock`.

Related to https://github.com/tensorflow/datasets/issues/1911#issuecomment-616219946

<details><summary><b> See pytest results </b></summary>
<p>

```
PS C:\Users\VIJAY\Desktop\GitHub_Repos\datasets> python .\tensorflow_datasets\image_classification\horses_or_humans_test.py
Running tests under Python 3.7.6: C:\ProgramData\Miniconda3\python.exe
[ RUN      ] HorsesOrHumansTest.test_baseclass
[       OK ] HorsesOrHumansTest.test_baseclass
[ RUN      ] HorsesOrHumansTest.test_download_and_prepare_as_dataset
Total configs: 0
I0420 02:50:07.489775  8064 dataset_builder.py:333] Generating dataset horses_or_humans (C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0)
I0420 02:50:07.489775  8064 dataset_builder.py:333] Generating dataset horses_or_humans (C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0)
Downloading and preparing dataset horses_or_humans/3.0.0 (download: Unknown size, generated: Unknown size, total: Unknown size) to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0...
I0420 02:50:07.567562  8064 dataset_builder.py:924] Generating split train
I0420 02:50:07.567562  8064 dataset_builder.py:924] Generating split train
Shuffling and writing examples to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-train.tfrecord
  0%|                                                                                                                                           | 0/2 [00:00<?, ? examples/sI 
0420 02:50:07.810911  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-train.tfrecord. Shard lengths: [2]
I0420 02:50:07.810911  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-train.tfrecord. Shard lengths: [2]
I0420 02:50:07.812914  8064 dataset_builder.py:924] Generating split test
I0420 02:50:07.812914  8064 dataset_builder.py:924] Generating split test
Shuffling and writing examples to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-test.tfrecord
  0%|                                                                                                                                           | 0/2 [00:00<?, ? examples/sI 
0420 02:50:07.974472  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-test.tfrecord. Shard lengths: [2]
I0420 02:50:07.974472  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-test.tfrecord. Shard lengths: [2]
I0420 02:50:07.992432  8064 dataset_builder.py:382] Computing statistics.
I0420 02:50:07.992432  8064 dataset_builder.py:382] Computing statistics.
Computing statistics...:   0%|                                                                                                                     | 0/2 [00:00<?, ? split/s]I0420 02:50:08.004396  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5
I0420 02:50:08.004396  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5
2020-04-20 02:50:08.007653: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX AVX2
Computing statistics...:  50%|██████████████████████████████████████████████████████▌                                                      | 1/2 [00:00<00:00,  1.15 split/s]I0420 02:50:08.873071  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5
I0420 02:50:08.873071  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0.incompleteWO0GI5
Computing statistics...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.80 split/s]
Dataset horses_or_humans downloaded and prepared to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0. Subsequent calls will 
reuse this data.
I0420 02:50:09.473466  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.473466  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.599129  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.599129  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.798595  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.798595  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.914287  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:09.914287  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.113752  8064 dataset_info.py:361] Load dataset info from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.113752  8064 dataset_info.py:361] Load dataset info from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.119736  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.119736  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.203512  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.203512  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.379043  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.379043  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.464814  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
I0420 02:50:10.464814  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmp81u89vgv\horses_or_humans\3.0.0
WARNING:tensorflow:From C:\ProgramData\Miniconda3\lib\contextlib.py:82: TensorFlowTestCase.test_session (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.
Instructions for updating:
Use `self.session()` or `self.cached_session()` instead.
W0420 02:50:10.659292  8064 deprecation.py:323] From C:\ProgramData\Miniconda3\lib\contextlib.py:82: TensorFlowTestCase.test_session (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.
Instructions for updating:
Use `self.session()` or `self.cached_session()` instead.
W0420 02:50:10.659292  8064 deprecation.py:323] From C:\ProgramData\Miniconda3\lib\contextlib.py:82: TensorFlowTestCase.test_session (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.
Instructions for updating:
Use `self.session()` or `self.cached_session()` instead.
Total configs: 0
I0420 02:50:10.676252  8064 dataset_builder.py:333] Generating dataset horses_or_humans (C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0)
I0420 02:50:10.676252  8064 dataset_builder.py:333] Generating dataset horses_or_humans (C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0)
Downloading and preparing dataset horses_or_humans/3.0.0 (download: Unknown size, generated: Unknown size, total: Unknown size) to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0...
I0420 02:50:10.690212  8064 dataset_builder.py:924] Generating split train
I0420 02:50:10.690212  8064 dataset_builder.py:924] Generating split train
Shuffling and writing examples to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-train.tfrecord
  0%|                                                                                                                                           | 0/2 [00:00<?, ? examples/sI 
0420 02:50:10.811913  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-train.tfrecord. Shard lengths: [2]
I0420 02:50:10.811913  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-train.tfrecord. Shard lengths: [2]
I0420 02:50:10.813880  8064 dataset_builder.py:924] Generating split test
I0420 02:50:10.813880  8064 dataset_builder.py:924] Generating split test
Shuffling and writing examples to C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-test.tfrecord
  0%|                                                                                                                                           | 0/2 [00:00<?, ? examples/sI 
0420 02:50:10.976445  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-test.tfrecord. Shard lengths: [2]
I0420 02:50:10.976445  8064 tfrecords_writer.py:227] Done writing C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5\horses_or_humans-test.tfrecord. Shard lengths: [2]
I0420 02:50:10.978439  8064 dataset_builder.py:382] Computing statistics.
I0420 02:50:10.978439  8064 dataset_builder.py:382] Computing statistics.
Computing statistics...:   0%|                                                                                                                     | 0/2 [00:00<?, ? split/s]I0420 02:50:10.990415  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5
I0420 02:50:10.990415  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split test, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5
Computing statistics...:  50%|██████████████████████████████████████████████████████▌                                                      | 1/2 [00:00<00:00,  3.65 split/s]I0420 02:50:11.263676  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5
I0420 02:50:11.263676  8064 dataset_builder.py:478] Constructing tf.data.Dataset for split train, from C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5
Computing statistics...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.74 split/s]
[  FAILED  ] HorsesOrHumansTest.test_download_and_prepare_as_dataset
[ RUN      ] HorsesOrHumansTest.test_info
[       OK ] HorsesOrHumansTest.test_info
[ RUN      ] HorsesOrHumansTest.test_registered
[       OK ] HorsesOrHumansTest.test_registered
[ RUN      ] HorsesOrHumansTest.test_session
[  SKIPPED ] HorsesOrHumansTest.test_session
======================================================================
ERROR: test_download_and_prepare_as_dataset (__main__.HorsesOrHumansTest)
test_download_and_prepare_as_dataset (__main__.HorsesOrHumansTest)
Run the decorated test method.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\VIJAY\Desktop\GitHub_Repos\datasets\tensorflow_datasets\testing\test_utils.py", line 205, in decorated
    f(self, *args, **kwargs)
  File "C:\Users\VIJAY\Desktop\GitHub_Repos\datasets\tensorflow_datasets\testing\dataset_builder_testing.py", line 298, in test_download_and_prepare_as_dataset
    self._download_and_prepare_as_dataset(self.builder)
  File "C:\Users\VIJAY\Desktop\GitHub_Repos\datasets\tensorflow_datasets\testing\dataset_builder_testing.py", line 359, in _download_and_prepare_as_dataset
    builder.download_and_prepare(download_config=download_config)
  File "C:\Users\VIJAY\Desktop\GitHub_Repos\datasets\tensorflow_datasets\core\api_utils.py", line 69, in disallow_positional_args_dec
    return fn(*args, **kwargs)
  File "C:\Users\VIJAY\Desktop\GitHub_Repos\datasets\tensorflow_datasets\core\dataset_builder.py", line 386, in download_and_prepare
    self.info.write_to_directory(self._data_dir)
  File "C:\ProgramData\Miniconda3\lib\contextlib.py", line 119, in __exit__
    next(self.gen)
  File "C:\Users\VIJAY\Desktop\GitHub_Repos\datasets\tensorflow_datasets\core\utils\py_utils.py", line 309, in incomplete_dir
    tf.io.gfile.rename(tmp_dir, dirname)
  File "C:\ProgramData\Miniconda3\lib\site-packages\tensorflow_core\python\lib\io\file_io.py", line 521, in rename_v2
    compat.as_bytes(src), compat.as_bytes(dst), overwrite)
tensorflow.python.framework.errors_impl.UnknownError: Failed to rename: C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0.incompleteWO0GI5 to: C:\Users\VIJAY\AppData\Local\Temp\horses_or_humans_testv9ls7ywi\tmpkogee3tp\horses_or_humans\3.0.0 : Access is denied.
; Input/output error

----------------------------------------------------------------------
Ran 5 tests in 4.557s

FAILED (errors=1, skipped=1)
PS C:\Users\VIJAY\Desktop\GitHub_Repos\datasets> 
```

</p>
</details>
