### PR TITLE
Change data URL

### DIFF
--- a/tensorflow_datasets/image_classification/horses_or_humans.py
+++ b/tensorflow_datasets/image_classification/horses_or_humans.py
@@ -34,8 +34,8 @@ url = "http://laurencemoroney.com/horses-or-humans-dataset"
 }
 """
 
-_TRAIN_URL = "https://storage.googleapis.com/laurencemoroney-blog.appspot.com/horse-or-human.zip"
-_TEST_URL = "https://storage.googleapis.com/laurencemoroney-blog.appspot.com/validation-horse-or-human.zip"
+_TRAIN_URL = "https://storage.googleapis.com/download.tensorflow.org/data/horse-or-human.zip"
+_TEST_URL = "https://storage.googleapis.com/download.tensorflow.org/data/validation-horse-or-human.zip"
 
 _IMAGE_SIZE = 300
 _IMAGE_SHAPE = (_IMAGE_SIZE, _IMAGE_SIZE, 3)


### PR DESCRIPTION
The data is hosted in lmoroney's GCS bucket. Changing this to tensorflow.org bucket


  
## Description

Update URLs for the data location to tensorflow.org instead of lmoroney's bucket
  
## Checklist
* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add checksums file
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] Add data generation script (if applicable)
* [ ] Lint code
