### PR TITLE
Fix DIV2K Reference

### DIFF
--- a/tensorflow_datasets/image/div2k.py
+++ b/tensorflow_datasets/image/div2k.py
@@ -29,14 +29,15 @@ import os.path
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
-_CITATION = """@InProceedings{Ignatov_2018_ECCV_Workshops,
-author = {Ignatov, Andrey and Timofte, Radu and others},
-title = {PIRM challenge on perceptual image enhancement on smartphones: report},
-booktitle = {European Conference on Computer Vision (ECCV) Workshops},
-url = "http://www.vision.ee.ethz.ch/~timofter/publications/Agustsson-CVPRW-2017.pdf",
-month = {January},
-year = {2019}
-}
+_CITATION = """
+@InProceedings{Agustsson_2017_CVPR_Workshops,
+	author = {Agustsson, Eirikur and Timofte, Radu},
+	title = {NTIRE 2017 Challenge on Single Image Super-Resolution: Dataset and Study},
+	booktitle = {The IEEE Conference on Computer Vision and Pattern Recognition (CVPR) Workshops},
+    url = "http://www.vision.ee.ethz.ch/~timofter/publications/Agustsson-CVPRW-2017.pdf",
+	month = {July},
+	year = {2017}
+} 
 """
 
 _DESCRIPTION = """


### PR DESCRIPTION
Reference for DIV2K updated to be consistent with
https://data.vision.ee.ethz.ch/cvl/DIV2K/
-- before the linked paper in url was not consistent with the reference.

  
## Description

<description>
  
## Checklist
* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add checksums file
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] Add data generation script (if applicable)
* [ ] Lint code
