### PR TITLE
Update checksums for oxford_iiit_pet dataset & visual_domain_decathlon

### DIFF
--- a/tensorflow_datasets/url_checksums/oxford_iiit_pet.txt
+++ b/tensorflow_datasets/url_checksums/oxford_iiit_pet.txt
@@ -1,2 +1,2 @@
-http://www.robots.ox.ac.uk/~vgg/data/pets/data/annotations.tar.gz 37969920 8568ffea346d0b62181808f9fe45d00d214e43a45cd9a28c55664a690bd4eb76
-http://www.robots.ox.ac.uk/~vgg/data/pets/data/images.tar.gz 802191360 5a13461893eb1873fa8ccf2ed6b6245af14fb3913c8686da1626c108c8522eea
+http://www.robots.ox.ac.uk/~vgg/data/pets/data/annotations.tar.gz 19173078 52425fb6de5c424942b7626b428656fcbd798db970a937df61750c0f1d358e91
+http://www.robots.ox.ac.uk/~vgg/data/pets/data/images.tar.gz 791918971 67195c5e1c01f1ab5f9b6a5d22b8c27a580d896ece458917e61d459337fa318d

--- a/tensorflow_datasets/url_checksums/visual_domain_decathlon.txt
+++ b/tensorflow_datasets/url_checksums/visual_domain_decathlon.txt
@@ -1,3 +1,3 @@
 http://www.image-net.org/image/decathlon/decathlon-1.0-data-imagenet.tar 6535075840 93caac18a907266f917136849c1db7bbf88dd595120af1a8eea7177138962e4a
-http://www.robots.ox.ac.uk/~vgg/share/decathlon-1.0-data.tar.gz 775157760 c0efa6249d68cc82bced2d2af187ff5b5199a3bdb7a99ac2085321188a65aa7a
-http://www.robots.ox.ac.uk/~vgg/share/decathlon-1.0-devkit.tar.gz 337909760 67053b669a66c6c8af3b17ada83d7c6b6e802e33ad4793722945be28838620fb
+http://www.robots.ox.ac.uk/~vgg/share/decathlon-1.0-data.tar.gz 406351554 8eca928bda025d855c91a78db45b3b18bc322efd7b1462a041e62c27b3c83c25
+http://www.robots.ox.ac.uk/~vgg/share/decathlon-1.0-devkit.tar.gz 23503205 f86d9e128678434ff2a3a374f00eb3e2ec2267e15e53ddae5f19ff19378b5ff7


### PR DESCRIPTION
Fix #1978
dataset_info gist : [here](https://gist.github.com/Eshan-Agarwal/e8c4cc3de37af00f02c0d19bef78f71b)