### PR TITLE
Update checksums of oxford_flowers102 and dtd datasets

### DIFF
--- a/tensorflow_datasets/url_checksums/dtd.txt
+++ b/tensorflow_datasets/url_checksums/dtd.txt
@@ -1,1 +1,1 @@
-https://www.robots.ox.ac.uk/~vgg/data/dtd/download/dtd-r1.0.1.tar.gz 637880320 6b2c060a070cc7e13042807a00294af51a75b4b89f82d480219da22002e79ce0
+https://www.robots.ox.ac.uk/~vgg/data/dtd/download/dtd-r1.0.1.tar.gz 625239812 e42855a52a4950a3b59612834602aa253914755c95b0cff9ead6d07395f8e205

--- a/tensorflow_datasets/url_checksums/oxford_flowers102.txt
+++ b/tensorflow_datasets/url_checksums/oxford_flowers102.txt
@@ -1,3 +1,3 @@
-https://www.robots.ox.ac.uk/~vgg/data/flowers/102/102flowers.tgz 353105920 ab4f0aa80bcf087a6841e317568ad8858fe121e7f60c4354d20c6be0869d03cc
+https://www.robots.ox.ac.uk/~vgg/data/flowers/102/102flowers.tgz 344862509 2d01ecc807db462958cfe3d92f57a8c252b4abd240eb955770201e45f783b246
 https://www.robots.ox.ac.uk/~vgg/data/flowers/102/imagelabels.mat 502 4903e94206bac23bf772aadf06451916df56b58fc483a62db32a97b82656651d
 https://www.robots.ox.ac.uk/~vgg/data/flowers/102/setid.mat 14989 46b8678f91fd95d3c8f4feab80d271a6c834a1dd896fe29fd3e6ad9ce5c8dccd


### PR DESCRIPTION
Fix #1977 

oxford_flowers102 : [dataset_info](https://gist.github.com/vijayphoenix/e8da593cce3498739439dbbf01c785e3)
dtd: [dataset_info](https://gist.github.com/vijayphoenix/3d5719db2ef8fb2e544ea088a7c4d32f)