### PR TITLE
Corrected Catalog Overview

### DIFF
--- a/tensorflow_datasets/scripts/documentation/templates/catalog_overview.mako.md
+++ b/tensorflow_datasets/scripts/documentation/templates/catalog_overview.mako.md
@@ -22,7 +22,8 @@ ds = ds.batch(32)
 # `tfds.as_numpy` converts `tf.Tensor` -> `np.array`
 for ex in tfds.as_numpy(ds):
   # `int2str` returns the human readable label ('dog', 'car',...)
-  print(info.features['label'].int2str(ex['label']))
+  for label in ex['label']:
+    print(info.features['label'].int2str(label))
 ```
 
 ## `##` starts a line comment for mako, so we have to come up with following


### PR DESCRIPTION
# Issue

* Issue Reference: fixes #2010 

* `Catalog Overview`: [https://www.tensorflow.org/datasets/catalog/overview](https://www.tensorflow.org/datasets/catalog/overview)

```python
# Build the `tf.data.Dataset` pipeline.
ds, info = tfds.load('cifar10', split='train', shuffle_files=True, with_info=True)
ds = ds.shuffle(info.splits['train'].num_examples)
ds = ds.batch(32)

# `tfds.as_numpy` converts `tf.Tensor` -> `np.array`
for ex in tfds.as_numpy(ds):
  # `int2str` returns the human readable label ('dog', 'car',...)
  print(info.features['label'].int2str(ex['label']))
```
The int2str function inside of the print function throws a ValueError because it's trying to print the label of 32 images at once.

## Description
Changed  above code to 
```python
# Build the `tf.data.Dataset` pipeline.
ds, info = tfds.load('cifar10', split='train', shuffle_files=True, with_info=True)
ds = ds.shuffle(info.splits['train'].num_examples)
ds = ds.batch(32)

# `tfds.as_numpy` converts `tf.Tensor` -> `np.array`
for ex in tfds.as_numpy(ds):
  # `int2str` returns the human readable label ('dog', 'car',...)
  for label in ex['label']:
    print(info.features['label'].int2str(label))
```
  