### PR TITLE
Update waymo open dataset

### DIFF
--- a/tensorflow_datasets/object_detection/waymo_open_dataset.py
+++ b/tensorflow_datasets/object_detection/waymo_open_dataset.py
@@ -43,11 +43,6 @@ This data is licensed for non-commercial use.
 WARNING: this dataset requires additional authorization and registration.
 Please look at tfds documentation for accessing GCS, and
 afterwards, please register via https://waymo.com/open/licensing/
-
-This dataset is also available in pre-processed format, making it faster
-to load, if you select the correct data_dir:
-tfds.load('waymo_open_dataset', \
-data_dir='gs://waymo_open_dataset_v_1_0_0_individual_files/tensorflow_datasets')
 """
 
 _HOMEPAGE_URL = "http://www.waymo.com/open/"
@@ -61,7 +56,7 @@ class WaymoOpenDataset(tfds.core.BeamBasedBuilder):
   """Waymo Open Dataset."""
 
   VERSION = tfds.core.Version("0.1.0")
-  _CLOUD_BUCKET = "gs://waymo_open_dataset_v_1_0_0_individual_files/"
+  _CLOUD_BUCKET = "gs://waymo_open_dataset_v_1_2_0_individual_files/"
 
   def _info(self):
 
@@ -132,6 +127,11 @@ class WaymoOpenDataset(tfds.core.BeamBasedBuilder):
         os.path.join(self._CLOUD_BUCKET, "validation/segment*camera*"))
     logging.info("Validation files: %s", validation_files)
 
+    # Testing set
+    test_files = tf.io.gfile.glob(
+        os.path.join(self._CLOUD_BUCKET, "testing/segment*camera*"))
+    logging.info("Testing files: %s", test_files)
+
     return [
         tfds.core.SplitGenerator(
             name=tfds.Split.TRAIN,
@@ -144,7 +144,14 @@ class WaymoOpenDataset(tfds.core.BeamBasedBuilder):
             name=tfds.Split.VALIDATION,
             gen_kwargs={
                 "tf_record_files": validation_files,
-            }),
+            }
+        ),
+        tfds.core.SplitGenerator(
+            name=tfds.Split.TEST,
+            gen_kwargs={
+                "tf_record_files": test_files,
+            }
+        ),
     ]
 
   def _build_pcollection(self, pipeline, tf_record_files):

--- a/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
+++ b/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
@@ -21,20 +21,28 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_datasets import testing
+from tensorflow_datasets.core import Version
 from tensorflow_datasets.object_detection import waymo_open_dataset
 
 
 class WaymoOpenDatasetTest(testing.DatasetBuilderTestCase):
   DATASET_CLASS = waymo_open_dataset.WaymoOpenDataset
+  BUILDER_CONFIG_NAMES_TO_TEST = ["test"]
   SPLITS = {
       "train": 1,  # Number of fake train example
       "validation": 1,  # Number of fake validation example
-      "test": 1,  # Number of fake test example
   }
 
   def setUp(self):
     super(WaymoOpenDatasetTest, self).setUp()
-    self.builder._CLOUD_BUCKET = self.example_dir
+    waymo_open_dataset.WaymoOpenDataset.BUILDER_CONFIGS.extend([
+        waymo_open_dataset.WaymoOpenDatasetConfig(
+            cloud_bucket=self.example_dir,
+            name="test",
+            version=Version("0.1.0"),
+            description="Waymo Open Dataset test config",
+        ),
+    ])
 
 
 if __name__ == "__main__":

--- a/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
+++ b/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
@@ -25,24 +25,31 @@ from tensorflow_datasets.core import Version
 from tensorflow_datasets.object_detection import waymo_open_dataset
 
 
+# waymo_open_dataset.WaymoOpenDataset.BUILDER_CONFIGS.extend([
+#     waymo_open_dataset.WaymoOpenDatasetConfig(
+#         cloud_bucket=None,
+#         name="test",
+#         version=Version("0.1.0"),
+#         description="Waymo Open Dataset test config",
+#     ),
+# ])
+
+
 class WaymoOpenDatasetTest(testing.DatasetBuilderTestCase):
+  """Waymo Open Dataset tests."""
+
   DATASET_CLASS = waymo_open_dataset.WaymoOpenDataset
-  BUILDER_CONFIG_NAMES_TO_TEST = ["test"]
+  BUILDER_CONFIG_NAMES_TO_TEST = ["v_1_0"]
   SPLITS = {
       "train": 1,  # Number of fake train example
       "validation": 1,  # Number of fake validation example
   }
 
   def setUp(self):
+    """Set up Waymo Open Dataset tests."""
     super(WaymoOpenDatasetTest, self).setUp()
-    waymo_open_dataset.WaymoOpenDataset.BUILDER_CONFIGS.extend([
-        waymo_open_dataset.WaymoOpenDatasetConfig(
-            cloud_bucket=self.example_dir,
-            name="test",
-            version=Version("0.1.0"),
-            description="Waymo Open Dataset test config",
-        ),
-    ])
+    self.builder.builder_config.cloud_bucket = self.example_dir
+    # waymo_open_dataset.WaymoOpenDataset.BUILDER_CONFIGS.
 
 
 if __name__ == "__main__":

--- a/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
+++ b/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
@@ -21,18 +21,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_datasets import testing
-from tensorflow_datasets.core import Version
 from tensorflow_datasets.object_detection import waymo_open_dataset
-
-
-# waymo_open_dataset.WaymoOpenDataset.BUILDER_CONFIGS.extend([
-#     waymo_open_dataset.WaymoOpenDatasetConfig(
-#         cloud_bucket=None,
-#         name="test",
-#         version=Version("0.1.0"),
-#         description="Waymo Open Dataset test config",
-#     ),
-# ])
 
 
 class WaymoOpenDatasetTest(testing.DatasetBuilderTestCase):
@@ -49,7 +38,6 @@ class WaymoOpenDatasetTest(testing.DatasetBuilderTestCase):
     """Set up Waymo Open Dataset tests."""
     super(WaymoOpenDatasetTest, self).setUp()
     self.builder.builder_config.cloud_bucket = self.example_dir
-    # waymo_open_dataset.WaymoOpenDataset.BUILDER_CONFIGS.
 
 
 if __name__ == "__main__":

--- a/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
+++ b/tensorflow_datasets/object_detection/waymo_open_dataset_test.py
@@ -28,7 +28,8 @@ class WaymoOpenDatasetTest(testing.DatasetBuilderTestCase):
   DATASET_CLASS = waymo_open_dataset.WaymoOpenDataset
   SPLITS = {
       "train": 1,  # Number of fake train example
-      "validation": 1,  # Number of fake test example
+      "validation": 1,  # Number of fake validation example
+      "test": 1,  # Number of fake test example
   }
 
   def setUp(self):


### PR DESCRIPTION
# Add Dataset

* Dataset Name: Waymo Open Dataset
* Issue Reference: #2096 
  
## Description

Update Waymo Open Dataset to add support for v1.1 and v1.2
Main changes among versions:
1. v1.1: Added camera labels for 900 segments
2. v1.2: Added Test Set with 150 segments, plus 800 segments for domain adaptation across Training, Validation, and Test

  
## Checklist
* [X] Address all TODO's
* [X] Add alphabetized import to subdirectory's `__init__.py`
* [X] Run `download_and_prepare` successfully
* [X] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [X] Properly cite in `BibTeX` format
* [X] Add passing test(s)
* [X] Add test data
* [X] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [X] Add data generation script (if applicable)
* [X] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
