### PR TITLE
Minor changes to GitHub workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,14 @@ dist/
 # Tests
 .pytest_cache/
 
+# Type checking
+.pytype/
+
 # Other
 *.DS_Store
 
 # PyCharm
 .idea
+
+# Visual Studio Code
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,7 @@ Thanks for thinking about contributing to our library !
 
 * Please accept the [Contributor License Agreement](https://cla.developers.google.com) (see below)
 * Comment on the issue that you plan to work on so we can assign it to you and
-  there isn't unnecessary duplication of work. If this is your first time
-  contributing, we'll send you an invitation on GitHub to be a contributor;
-  you must accept this invitation
-  [here](https://github.com/tensorflow/datasets/settings/collaboration)
-  before we can assign you the issue.
+  there isn't unnecessary duplication of work.
 * When you plan to work on something larger (for example, adding new
   `FeatureConnectors`), please respond on the issue (or create one if there
   isn't one) to explain your plan and give others a chance to discuss.


### PR DESCRIPTION
- We can assign an issue without sending an invite.
- Ignore folders created by pytype CLI tool and vscode editor 