### PR TITLE
Made correction for an example in docstring

### DIFF
--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -180,7 +180,7 @@ def _add_ragged_fields(example_data, tensor_info):
   tensor_info = TensorInfo(shape=(None, None,), sequence_rank=2, ...)
   out = _add_ragged_fields(example_data, tensor_info)
   out == {
-      'ragged_flat_values': ([0, 1, 2, 3, 4, 5], TensorInfo(shape=(), ...)),
+      'ragged_flat_values': ([1, 2, 3, 4, 5], TensorInfo(shape=(), ...)),
       'ragged_row_length_0': ([3, 0, 2], TensorInfo(shape=(None,), ...))
   }
   ```


### PR DESCRIPTION
The docstring for `_add_ragged_fields` function in `tensorflow_datasets.core.example_serializer` seems to be incorrect. With input data
```
example_data = [
    [1, 2, 3],
    [],
    [4, 5]
]
```
The original docstring states that the output should be 
```
{
      'ragged_flat_values': ([0, 1, 2, 3, 4, 5], TensorInfo(shape=(), ...)),
      'ragged_row_length_0': ([3, 0, 2], TensorInfo(shape=(None,), ...))
  }
```
However, according to my understanding and `example_serializer_test`, The output should be
```
{
    'ragged_flat_values': ([1, 2, 3, 4, 5], TensorInfo(shape=(), ...)),
    'ragged_row_length_0': ([3, 0, 2], TensorInfo(shape=(None,), ...))
}
```
This PR fixes this error to avoid confusion.

@vancezuo Could you please review this pull request?