### PR TITLE
Remove redundant shape and string checks to improve performance

### DIFF
--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -122,19 +122,13 @@ def _item_to_np_array(item, dtype, shape):
   utils.assert_shape_match(item.shape, shape)
   if dtype == tf.string and not _is_string(original_item):
     raise ValueError(
-        "Unsuported value: {}\nCould not convert to bytes list.".format(item))
+        "Unsupported value: {}\nCould not convert to bytes list.".format(item))
   return item
 
 
 def _item_to_tf_feature(item, tensor_info):
   """Single item to a tf.train.Feature."""
   v = _item_to_np_array(item, shape=tensor_info.shape, dtype=tensor_info.dtype)
-
-  # Check that the shape is expected
-  utils.assert_shape_match(v.shape, tensor_info.shape)
-  if tensor_info.dtype == tf.string and not _is_string(v):
-    raise ValueError(
-        "Unsuported value: {}\nCould not convert to bytes list.".format(item))
 
   # Convert boolean to integer (tf.train.Example does not support bool)
   if v.dtype == np.bool_:
@@ -150,7 +144,7 @@ def _item_to_tf_feature(item, tensor_info):
     return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
   else:
     raise ValueError(
-        "Unsuported value: {}.\n"
+        "Unsupported value: {}.\n"
         "tf.train.Feature does not support type {}. "
         "This may indicate that one of the FeatureConnectors received an "
         "unsupported value as input.".format(repr(v), repr(type(v)))

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import textwrap
 import numpy as np
 import tensorflow.compat.v2 as tf
 
@@ -200,6 +201,23 @@ class ExampleSerializerTest(testing.SubTestCase):
         [4, 5],
     ])
     self.assertEqual(out[1], tensor_info)
+
+  def test_item_to_tf_feature_incorrect_shape(self):
+    # Test shape check in _item_to_tf_feature raises ValueError.
+    example_item = [1, 2, 3, 4, 5]
+    tensor_info = feature_lib.TensorInfo(shape=(4,), dtype=tf.int64)
+    with self.assertRaises(ValueError):
+      example_serializer._item_to_tf_feature(example_item, tensor_info)
+
+  def test_item_to_tf_feature_string_check(self):
+    # Test string check in _item_to_tf_feature raises ValueError.
+    example_item = [1, 2, 3, 4, 5]
+    tensor_info = feature_lib.TensorInfo(shape=(5,), dtype=tf.string)
+    with self.assertRaisesRegex(
+        ValueError,
+        'Unsupported value: (.*)\nCould not convert to bytes list.',
+    ):
+      example_serializer._item_to_tf_feature(example_item, tensor_info)
 
 
 if __name__ == '__main__':

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import textwrap
 import numpy as np
 import tensorflow.compat.v2 as tf
 


### PR DESCRIPTION
1. Added unit tests to check that in `_item_to_tf_feature` from `tensorflow_datasets.core.example_serializer`, a `ValueError` is raised when
  - the shape of `item` is not compatible with `tensor_info.shape`.
  - `tensor_info.dtype == tf.string` but `item` is not string.
2. Removed redundant checks in `_item_to_tf_feature`. These checks are already performed in `_item_to_np_array`, which is called in the first line of `_item_to_tf_feature`. Performing this check again in `_item_to_tf_feature` would be redundant and slows down data preparation time.

  - The added unit tests confirm that a `ValueError` would still be raised in corresponding scenarios.

  - Performance benchmark: tested with the following command with the data already downloaded.
`time python3 -m tensorflow_datasets.scripts.download_and_prepare --datasets=amazon_us_reviews/Video_v1_00`
Before removing redundant checks: 9m19.551s
After removing redundant checks: 8m9.382s 

3. Fixed typos in `tensorflow_datasets.core.example_serializer`.

@vancezuo Could you please review this PR?