### PR TITLE
Optimizing run_with_reraise

### DIFF
--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -69,10 +69,12 @@ def _dict_to_tf_example(example_dict, tensor_info_dict):
     example_proto: `tf.train.Example`, the encoded example proto.
   """
   def run_with_reraise(fn, k, example_data, tensor_info):
-    try:
-      return fn(example_data, tensor_info)
-    except Exception:
-      utils.reraise("Error while serializing feature `{}`: `{}`: ".format(k, tensor_info))
+     try:
+       return fn(example_data, tensor_info)
+     except Exception:
+       utils.reraise(
+           'Error while serializing feature `{}`: `{}`: '.format(k, tensor_info)
+       )
 
   if tensor_info_dict:
     # Add the RaggedTensor fields for the nested sequences

--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -69,9 +69,10 @@ def _dict_to_tf_example(example_dict, tensor_info_dict):
     example_proto: `tf.train.Example`, the encoded example proto.
   """
   def run_with_reraise(fn, k, example_data, tensor_info):
-    with utils.try_reraise(
-        "Error while serializing feature `{}`: `{}`: ".format(k, tensor_info)):
+    try:
       return fn(example_data, tensor_info)
+    except Exception:
+      utils.reraise("Error while serializing feature `{}`: `{}`: ".format(k, tensor_info))
 
   if tensor_info_dict:
     # Add the RaggedTensor fields for the nested sequences

--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -71,7 +71,7 @@ def _dict_to_tf_example(example_dict, tensor_info_dict):
   def run_with_reraise(fn, k, example_data, tensor_info):
      try:
        return fn(example_data, tensor_info)
-     except Exception:
+     except Exception:  # pylint: disable=broad-except
        utils.reraise(
            'Error while serializing feature `{}`: `{}`: '.format(k, tensor_info)
        )

--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -69,12 +69,12 @@ def _dict_to_tf_example(example_dict, tensor_info_dict):
     example_proto: `tf.train.Example`, the encoded example proto.
   """
   def run_with_reraise(fn, k, example_data, tensor_info):
-     try:
-       return fn(example_data, tensor_info)
-     except Exception:  # pylint: disable=broad-except
-       utils.reraise(
-           'Error while serializing feature `{}`: `{}`: '.format(k, tensor_info)
-       )
+    try:
+      return fn(example_data, tensor_info)
+    except Exception:  # pylint: disable=broad-except
+      utils.reraise(
+          'Error while serializing feature `{}`: `{}`: '.format(k, tensor_info)
+      )
 
   if tensor_info_dict:
     # Add the RaggedTensor fields for the nested sequences

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -219,7 +219,7 @@ class ExampleSerializerTest(testing.SubTestCase):
       example_serializer._item_to_tf_feature(example_item, tensor_info)
 
   def test_dict_to_tf_example_error_reraise(self):
-    # Test error reraise in _dict_to_tf_example
+    # Test error reraise in _dict_to_tf_example.
     example_data = {'input': [1, 2, 3]}
     tensor_info = {
         'input': feature_lib.TensorInfo(
@@ -229,15 +229,12 @@ class ExampleSerializerTest(testing.SubTestCase):
     }
     with self.assertRaisesRegex(
         ValueError,
-        (
-            '^Error while serializing feature `input`:'
-            ' `TensorInfo\(shape=\(2,\), dtype=tf.int64\)`:(.*)'
-        ),
+        '^Error while serializing feature `input`:',
     ):
       example_serializer._dict_to_tf_example(example_data, tensor_info)
 
   def test_dict_to_tf_example_flatten_nest_dict(self):
-    # Test that a KeyError from zip_dict in _dict_to_tf_example is not reraised
+    # Test that a KeyError from zip_dict in _dict_to_tf_example is not reraised.
     example_data = {'x': [1, 2, 3]}
     tensor_info = {
         'y': feature_lib.TensorInfo(

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -229,7 +229,7 @@ class ExampleSerializerTest(testing.SubTestCase):
     }
     with self.assertRaisesRegex(
         ValueError,
-        '^Error while serializing feature `input`:',
+        '^Error while serializing feature `input`:(.*)',
     ):
       example_serializer._dict_to_tf_example(example_data, tensor_info)
 

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -230,9 +230,24 @@ class ExampleSerializerTest(testing.SubTestCase):
     with self.assertRaisesRegex(
         ValueError,
         (
-            'Error while serializing feature `input`:'
+            '^Error while serializing feature `input`:'
             ' `TensorInfo\(shape=\(2,\), dtype=tf.int64\)`:(.*)'
         ),
+    ):
+      example_serializer._dict_to_tf_example(example_data, tensor_info)
+
+  def test_dict_to_tf_example_flatten_nest_dict(self):
+    # Test that a KeyError from zip_dict in _dict_to_tf_example is not reraised
+    example_data = {'x': [1, 2, 3]}
+    tensor_info = {
+        'y': feature_lib.TensorInfo(
+            shape=(2,),
+            dtype=tf.int64,
+        ),
+    }
+    with self.assertRaisesRegex(
+        KeyError,
+        '^(?!Error while serializing feature)(.*)',
     ):
       example_serializer._dict_to_tf_example(example_data, tensor_info)
 

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -20,8 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import re
-
 import numpy as np
 import tensorflow.compat.v2 as tf
 
@@ -229,12 +227,10 @@ class ExampleSerializerTest(testing.SubTestCase):
             dtype=tf.int64,
         ),
     }
-    error_regex_pattern = re.escape(
-        'Error while serializing feature `input`: `{}`: '.format(
-            tensor_info['input'],
-        ),
-    )
-    with self.assertRaisesRegex(ValueError, error_regex_pattern):
+    with self.assertRaisesRegex(
+        ValueError,
+        '^Error while serializing feature `input`:(.*)'
+    ):
       example_serializer._dict_to_tf_example(example_data, tensor_info)
 
   def test_dict_to_tf_example_flatten_nest_dict(self):

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -218,6 +218,24 @@ class ExampleSerializerTest(testing.SubTestCase):
     ):
       example_serializer._item_to_tf_feature(example_item, tensor_info)
 
+  def test_dict_to_tf_example_error_reraise(self):
+    # Test error reraise in _dict_to_tf_example
+    example_data = {'input': [1, 2, 3]}
+    tensor_info = {
+        'input': feature_lib.TensorInfo(
+            shape=(2,),
+            dtype=tf.int64,
+        ),
+    }
+    with self.assertRaisesRegex(
+        ValueError,
+        (
+            'Error while serializing feature `input`:'
+            ' `TensorInfo\(shape=\(2,\), dtype=tf.int64\)`:(.*)'
+        ),
+    ):
+      example_serializer._dict_to_tf_example(example_data, tensor_info)
+
 
 if __name__ == '__main__':
   testing.test_main()

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import re
+
 import numpy as np
 import tensorflow.compat.v2 as tf
 
@@ -227,10 +229,12 @@ class ExampleSerializerTest(testing.SubTestCase):
             dtype=tf.int64,
         ),
     }
-    with self.assertRaisesRegex(
-        ValueError,
-        '^Error while serializing feature `input`:(.*)',
-    ):
+    error_regex_pattern = re.escape(
+        'Error while serializing feature `input`: `{}`: '.format(
+            tensor_info['input'],
+        ),
+    )
+    with self.assertRaisesRegex(ValueError, error_regex_pattern):
       example_serializer._dict_to_tf_example(example_data, tensor_info)
 
   def test_dict_to_tf_example_flatten_nest_dict(self):


### PR DESCRIPTION
1. Added unit tests to check that in `_dict_to_tf_example` from `tensorflow_datasets.core.example_serializer`
  - when an error is raised during the processing of a feature, the exception is reraised with the corresponding prefix.
  - when an error is raised but not during the processing of a feature (for instance during `zip_dict`), the exception is raised directly without reraise.
2. Changed `run_with_reraise` in `_dict_to_tf_example` from using a context manager to using a try except block. Since Python context manager is expensive in terms of performance, such change reduced the time required for preparing data.

  - The added unit tests confirm that an error raised during the processing of a feature would be reraised with the correct prefix message.

  - Performance benchmark: tested with the following command with the data already downloaded.
`time python3 -m tensorflow_datasets.scripts.download_and_prepare --datasets=amazon_us_reviews/Video_v1_00`
Before removing the context manager: 7m21.970s
After removing the context manager: 6m28.479s

@vancezuo Could you please review this PR?