### PR TITLE
Remove py_utils.abstractclassmethod

### DIFF
--- a/tensorflow_datasets/core/features/text/text_encoder.py
+++ b/tensorflow_datasets/core/features/text/text_encoder.py
@@ -29,7 +29,6 @@ import re
 
 import six
 import tensorflow.compat.v2 as tf
-from tensorflow_datasets.core.utils import py_utils
 
 
 def _re_compile(pattern):
@@ -101,7 +100,8 @@ class TextEncoder(object):
     """Store to file. Inverse of load_from_file."""
     raise NotImplementedError
 
-  @py_utils.abstractclassmethod
+  @classmethod
+  @abc.abstractmethod
   def load_from_file(cls, filename_prefix):  # pylint: disable=no-self-argument
     """Load from file. Inverse of save_to_file."""
     raise NotImplementedError

--- a/tensorflow_datasets/core/utils/py_utils.py
+++ b/tensorflow_datasets/core/utils/py_utils.py
@@ -363,16 +363,6 @@ def atomic_write(path, mode):
   tf.io.gfile.rename(tmp_path, path, overwrite=True)
 
 
-class abstractclassmethod(classmethod):  # pylint: disable=invalid-name
-  """Decorate a method to mark it as an abstract @classmethod."""
-
-  __isabstractmethod__ = True
-
-  def __init__(self, fn):
-    fn.__isabstractmethod__ = True
-    super(abstractclassmethod, self).__init__(fn)
-
-
 def get_tfds_path(relative_path):
   """Returns absolute path to file given path relative to tfds root."""
   path = os.path.join(tfds_dir(), relative_path)


### PR DESCRIPTION
Since Python 3.3 it has been possible to use `classmethod` with `abstractmethod()`, making this decorator redundant.