### PR TITLE
Set __slots__ for frequently used classes

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -72,6 +72,8 @@ class BuilderConfig(object):
   `BuilderConfig` and add their own properties.
   """
 
+  __slots__ = ["_name", "_version", "_supported_versions", "_description"]
+
   @api_utils.disallow_positional_args
   def __init__(self, name, version=None, supported_versions=None,
                description=None):

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -72,8 +72,6 @@ class BuilderConfig(object):
   `BuilderConfig` and add their own properties.
   """
 
-  __slots__ = ["_name", "_version", "_supported_versions", "_description"]
-
   @api_utils.disallow_positional_args
   def __init__(self, name, version=None, supported_versions=None,
                description=None):

--- a/tensorflow_datasets/core/features/feature.py
+++ b/tensorflow_datasets/core/features/feature.py
@@ -102,6 +102,8 @@ from tensorflow_datasets.core import utils
 class TensorInfo(object):
   """Structure containing info on the `tf.Tensor` shape/dtype."""
 
+  __slots__ = ["shape", "dtype", "default_value", "sequence_rank"]
+
   def __init__(self, shape, dtype, default_value=None, sequence_rank=None):
     """Constructor.
 

--- a/tensorflow_datasets/core/utils/tf_utils.py
+++ b/tensorflow_datasets/core/utils/tf_utils.py
@@ -62,6 +62,8 @@ class TFGraphRunner(object):
 
   """
 
+  __slots__ = ["_graph_run_cache"]
+
   def __init__(self):
     """Constructor."""
     # Cache containing all compiled graph and opened session. Only used in


### PR DESCRIPTION
Frequently used objects can benefit from defining [`__slots__`](https://docs.python.org/3/reference/datamodel.html#slots).

From the Python docs:
> `__slots__` allow us to explicitly declare data members (like properties) and deny the creation of `__dict__` and `__weakref__` (unless explicitly declared in `__slots__` or available in a parent.)
The space saved over using `__dict__` can be significant. Attribute lookup speed can be significantly improved as well.

This PR explicitely defines `__slots__` for some frequently used classes that have very few attributes, tend not to be inherited from and don't use dynamic assignment of new variables.