### PR TITLE
Update catalog nightly note

### DIFF
--- a/docs/catalog/overview.md
+++ b/docs/catalog/overview.md
@@ -4,7 +4,8 @@ file. -->
 
 # Datasets
 
-Note: The datasets marked with `nights-stay` are available only in the TFDS nightly package `tfds-nightly`.
+Note: The datasets marked with `nights-stay` are available only in the TFDS
+nightly package `tfds-nightly`.
 
 --------------------------------------------------------------------------------
 

--- a/docs/catalog/overview.md
+++ b/docs/catalog/overview.md
@@ -4,9 +4,7 @@ file. -->
 
 # Datasets
 
-Note: The datasets documented here are from `HEAD` and so not all are available
-in the current `tensorflow-datasets` package. They are all accessible in our
-nightly package `tfds-nightly`.
+Note: The datasets marked with `nights-stay` are available only in the TFDS nightly package `tfds-nightly`.
 
 --------------------------------------------------------------------------------
 

--- a/docs/catalog/overview.md
+++ b/docs/catalog/overview.md
@@ -4,8 +4,7 @@ file. -->
 
 # Datasets
 
-Note: The datasets marked with `nights-stay` are available only in the TFDS
-nightly package `tfds-nightly`.
+Note: The datasets marked with <span class="material-icons" title="Available only in the tfds-nightly package">nights_stay</span> are available only in the TFDS nightly package `tfds-nightly`.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Updated the nightly note in [catalog overview](https://github.com/tensorflow/datasets/blob/master/docs/catalog/overview.md) to mention dataset marked with nights-stay are available only in TFDS nightly.