### PR TITLE
Update auto caching docs

### DIFF
--- a/docs/performances.md
+++ b/docs/performances.md
@@ -58,6 +58,8 @@ By default, TFDS auto-caches datasets which satisfy the following constraints:
 *   Total dataset size (all splits) is defined and < 250 MiB
 *   `shuffle_files` is disabled, or only a single shard is read
 
+Datasets with unknown metadata are not auto-cached.
+
 It is possible to opt out of auto-caching by passing `try_autocaching=False` to
 `tfds.ReadConfig` in `tfds.load`. Have a look at the dataset catalog
 documentation to see if a specific dataset will use auto-cache.

--- a/tensorflow_datasets/scripts/documentation/templates/dataset.mako.md
+++ b/tensorflow_datasets/scripts/documentation/templates/dataset.mako.md
@@ -90,8 +90,7 @@ def build_autocached_info(builder):
       assert not cache_shuffled and cache_unshuffled
       unshuffle_cached.add(split_name)
 
-
-  if not len(builder.info.splits):
+  if not len(builder.info.splits) or not builder.info.dataset_size:
     autocached_info = 'Unknown'
   elif len(always_cached) == len(builder.info.splits.keys()):
     autocached_info = 'Yes'  # All splits are auto-cached.


### PR DESCRIPTION
## Description

Changed "Auto-caching: No" to "unknown" when dataset size is unknown and added description to indicate that datasets with unknown metadata are not Auto-cached.
