### PR TITLE
Update URL of the dataset Plant Village

### DIFF
--- a/tensorflow_datasets/image_classification/plant_village.py
+++ b/tensorflow_datasets/image_classification/plant_village.py
@@ -58,7 +58,7 @@ Original paper URL: https://arxiv.org/abs/1511.08060
 Dataset URL: https://data.mendeley.com/datasets/tywbtsjrjv/1
 """
 
-_URL = "https://data.mendeley.com/datasets/tywbtsjrjv/1/files/127d0761-7c63-46f0-b08e-d0d9f7cad9da/Plant_leaf_diseases_dataset_without_augmentation.zip"
+_URL = "https://data.mendeley.com/datasets/tywbtsjrjv/1/files/d5652a28-c1d8-4b76-97f3-72fb80f94efc/Plant_leaf_diseases_dataset_without_augmentation.zip"
 _LABELS = [
     "Apple___Apple_scab",
     "Apple___Black_rot",


### PR DESCRIPTION
The url in the file, was throwing  error 404, and when you try to access it, it says Page not found The page you are looking for was not found, actually its a different URL from the TF docs (https://www.tensorflow.org/datasets/catalog/plant_village), I've added the correct one from https://data.mendeley.com/datasets/tywbtsjrjv/1

# Add Dataset

* Dataset Name: <Plant_Village>
* Issue Reference: https://github.com/tensorflow/tensorflow/issues/41051

  
## Description
It's and update of the URL
