### PR TITLE
Fix librispeech dataset path to transcript

### DIFF
--- a/tensorflow_datasets/audio/librispeech.py
+++ b/tensorflow_datasets/audio/librispeech.py
@@ -199,7 +199,7 @@ def _generate_librispeech_examples(directory):
   transcripts_glob = os.path.join(directory, "LibriSpeech", "*/*/*/*.txt")
   for transcript_file in tf.io.gfile.glob(transcripts_glob):
     path = os.path.dirname(transcript_file)
-    with tf.io.gfile.GFile(os.path.join(path, transcript_file)) as f:
+    with tf.io.gfile.GFile(transcript_file) as f:
       for line in f:
         line = line.strip()
         key, transcript = line.split(" ", 1)


### PR DESCRIPTION
Transcript path is incorrect because it includes the directory path twice.

i.e. Path is supposed to be `example/path/to/Librispeech/*/*/*/*.txt` 
and not `example/path/to/example/path/to/Librispeech/*/*/*/*.txt`