### PR TITLE
Set minimal supported Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,7 @@ setup(
     },
     scripts=[],
     install_requires=REQUIRED_PKGS,
+    python_requires='>=3.6',
     extras_require=EXTRAS_REQUIRE,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
As mentioned in #2199 TFDS requires Python 3.6 or newer. This PR correctly sets [`python_requires`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) in `setup.py` in order to raise a proper proper error message when trying to install TFDS on older versions of Python.

Adresses #2199 
/cc @Conchylicultor 