### PR TITLE
Update Caltech Birds dataset download urls

### DIFF
--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -47,15 +47,15 @@ _NAME_RE = re.compile(r"((\w*)/)*(\d*).(\w*)/(\w*.jpg)$")
 class CaltechBirds2010(tfds.core.GeneratorBasedBuilder):
   """Caltech Birds 2010 dataset."""
 
-  VERSION = tfds.core.Version("0.1.0")
+  VERSION = tfds.core.Version("0.1.1")
 
   @property
   def _caltech_birds_info(self):
     return CaltechBirdsInfo(
         name=self.name,
-        images_url="http://www.vision.caltech.edu/visipedia-data/CUB-200/images.tgz",
-        split_url="http://www.vision.caltech.edu/visipedia-data/CUB-200/lists.tgz",
-        annotations_url="http://www.vision.caltech.edu/visipedia-data/CUB-200/annotations.tgz",
+        images_url="https://drive.google.com/uc?export=download&id=1GDr1OkoXdhaXWGA8S3MAq3a522Tak-nx",
+        split_url="https://drive.google.com/uc?export=download&id=1vZuZPqha0JjmwkdaS_XtYryE3Jf5Q1AC",
+        annotations_url="https://drive.google.com/uc?export=download&id=16NsbTpMs5L6hT4hUJAmpW2u7wH326WTR",
     )
 
   def _info(self):
@@ -202,15 +202,15 @@ class CaltechBirds2010(tfds.core.GeneratorBasedBuilder):
 class CaltechBirds2011(CaltechBirds2010):
   """Caltech Birds 2011 dataset."""
 
-  VERSION = tfds.core.Version("0.1.0")
+  VERSION = tfds.core.Version("0.1.1")
 
   @property
   def _caltech_birds_info(self):
     return CaltechBirdsInfo(
         name=self.name,
-        images_url="http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz",
+        images_url="https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
         split_url=None,
-        annotations_url="http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/segmentations.tgz"
+        annotations_url="https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP"
     )
 
   def _info(self):

--- a/tensorflow_datasets/url_checksums/caltech_birds2010.txt
+++ b/tensorflow_datasets/url_checksums/caltech_birds2010.txt
@@ -1,3 +1,3 @@
-http://www.vision.caltech.edu/visipedia-data/CUB-200/annotations.tgz 11531634 c17b7841c21a66aa44ba8fe92369cc95dfc998946081828b1d7b8a4b716805c1
-http://www.vision.caltech.edu/visipedia-data/CUB-200/images.tgz 679421896 2a6d2246bbb9778ca03aa94e2e683ccb4f8821a36b7f235c0822e659d60a803e
-http://www.vision.caltech.edu/visipedia-data/CUB-200/lists.tgz 201844 aeacbd5e3539ae84ea726e8a266a9a119c18f055cd80f3836d5eb4500b005428
+https://drive.google.com/uc?export=download&id=16NsbTpMs5L6hT4hUJAmpW2u7wH326WTR 11531634 c17b7841c21a66aa44ba8fe92369cc95dfc998946081828b1d7b8a4b716805c1
+https://drive.google.com/uc?export=download&id=1GDr1OkoXdhaXWGA8S3MAq3a522Tak-nx 679421896 2a6d2246bbb9778ca03aa94e2e683ccb4f8821a36b7f235c0822e659d60a803e
+https://drive.google.com/uc?export=download&id=1vZuZPqha0JjmwkdaS_XtYryE3Jf5Q1AC 201844 aeacbd5e3539ae84ea726e8a266a9a119c18f055cd80f3836d5eb4500b005428

--- a/tensorflow_datasets/url_checksums/caltech_birds2011.txt
+++ b/tensorflow_datasets/url_checksums/caltech_birds2011.txt
@@ -1,2 +1,2 @@
-http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz 1150585339 0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081
-http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/segmentations.tgz 39272883 dc77f6cffea0cbe2e41d4201115c8f29a6320ecb04fffd2444f51b8066e4b84f
+https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45 1150585339 0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081
+https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP 39272883 dc77f6cffea0cbe2e41d4201115c8f29a6320ecb04fffd2444f51b8066e4b84f


### PR DESCRIPTION
Fix #2272 
The old download URLs redirect to drive links

View [dataset_info](https://gist.github.com/vijayphoenix/5cfca1eae1056b4f500627b9dd822902) gist