### PR TITLE
Add subsplit API for Better auto-sharding

### DIFF
--- a/tensorflow_datasets/core/__init__.py
+++ b/tensorflow_datasets/core/__init__.py
@@ -41,6 +41,7 @@ from tensorflow_datasets.core.splits import SplitDict
 from tensorflow_datasets.core.splits import SplitGenerator
 from tensorflow_datasets.core.splits import SplitInfo
 from tensorflow_datasets.core.splits import SubSplitInfo
+from tensorflow_datasets.core.splits import subsplits
 
 from tensorflow_datasets.core.tfrecords_reader import ReadInstruction
 

--- a/tensorflow_datasets/core/splits.py
+++ b/tensorflow_datasets/core/splits.py
@@ -247,3 +247,12 @@ class SplitGenerator(object):
     self.name = name
     self.gen_kwargs = gen_kwargs or {}
     self.split_info = SplitInfo(name=str(name))
+
+def subsplits(
+    split_name: str,
+    num_subsplits: int,
+) -> List[str]:
+  assert num_subsplits > 0
+  partitions = [round(i*100/num_subsplits) for i in range(num_subsplits+1)]
+  return [f'{split_name}[{partitions[i]}%:{partitions[i+1]}%]'
+          for i in range(num_subsplits)]

--- a/tensorflow_datasets/core/splits_test.py
+++ b/tensorflow_datasets/core/splits_test.py
@@ -183,6 +183,12 @@ class SplitsTest(testing.TestCase):
     self.assertEqual(repr(splits.Split.TRAIN), "Split('train')")
     self.assertIsInstance(splits.Split.TRAIN, splits.Split)
 
+  def test_subsplits_api(self):
+    self.assertEqual(['train[0%:33%]', 'train[33%:67%]', 'train[67%:100%]'],
+                     splits.subsplits('train', 3))
+    self.assertEqual(['train[0%:25%]', 'train[25%:50%]', 'train[50%:75%]',
+                      'train[75%:100%]'], splits.subsplits('train', 4))
+
 
 if __name__ == "__main__":
   testing.test_main()

--- a/tensorflow_datasets/public_api.py
+++ b/tensorflow_datasets/public_api.py
@@ -38,6 +38,7 @@ from tensorflow_datasets.core.registered import builder_cls
 from tensorflow_datasets.core.registered import list_builders
 from tensorflow_datasets.core.registered import load
 from tensorflow_datasets.core.splits import Split
+from tensorflow_datasets.core.splits import subsplits
 from tensorflow_datasets.core.utils.gcs_utils import is_dataset_on_gcs
 from tensorflow_datasets.core.utils.read_config import ReadConfig
 from tensorflow_datasets.core.utils.tqdm_utils import disable_progress_bar
@@ -73,6 +74,7 @@ __all__ = [
     "load",
     "ReadConfig",
     "Split",
+    "subsplits",
     "show_examples",
     "show_statistics",
     "testing",


### PR DESCRIPTION
Fix https://github.com/tensorflow/datasets/issues/2133
TODO: 
- [x] Auto-apply the subsplit API if `num_shards` < `num_pipelines` and `input_context` is provided.

Usage Example:

```python
ds = tfds.load('mnist',
               split=tfds.subsplit(split_name='train', num_subsplits=2),
               read_config=read_config)

```