### PR TITLE
Fix typo in dataset markdown builder

### DIFF
--- a/docs/catalog/imagenet2012.md
+++ b/docs/catalog/imagenet2012.md
@@ -79,7 +79,7 @@ corresponding labels file. See imagenet2012_labels.txt.
 
 *   **Manual download instructions**: This dataset requires you to
     download the source data manually into `download_config.manual_dir`
-    (defaults to `~/tensorflow_datasets/download/manual/`):<br/>
+    (defaults to `~/tensorflow_datasets/downloads/manual/`):<br/>
     manual_dir should contain two files: ILSVRC2012_img_train.tar and
     ILSVRC2012_img_val.tar.
     You need to register on http://www.image-net.org/download-images in order

--- a/tensorflow_datasets/scripts/documentation/dataset_markdown_builder.py
+++ b/tensorflow_datasets/scripts/documentation/dataset_markdown_builder.py
@@ -227,7 +227,7 @@ class ManualDatasetSection(Section):
         f"""
         This dataset requires you to
         download the source data manually into `download_config.manual_dir`
-        (defaults to `~/tensorflow_datasets/download/manual/`):<br/>
+        (defaults to `~/tensorflow_datasets/downloads/manual/`):<br/>
         {tfds.core.utils.indent(manual_instructions, '        ')}
         """
     )


### PR DESCRIPTION
According to the [code](https://github.com/tensorflow/datasets/blob/cf76046da843b997caa1e33855b546c67bb40c5a/tensorflow_datasets/core/dataset_builder.py#L768) and [comments](https://github.com/tensorflow/datasets/blob/cf76046da843b997caa1e33855b546c67bb40c5a/tensorflow_datasets/core/dataset_builder.py#L280) here.