### PR TITLE
Fix wrong default path of the manual download directory in documentation

### DIFF
--- a/tensorflow_datasets/scripts/documentation/dataset_markdown_builder.py
+++ b/tensorflow_datasets/scripts/documentation/dataset_markdown_builder.py
@@ -227,7 +227,7 @@ class ManualDatasetSection(Section):
         f"""
         This dataset requires you to
         download the source data manually into `download_config.manual_dir`
-        (defaults to `~/tensorflow_datasets/download/manual/`):<br/>
+        (defaults to `~/tensorflow_datasets/downloads/manual/`):<br/>
         {tfds.core.utils.indent(manual_instructions, '        ')}
         """
     )


### PR DESCRIPTION
The manual download dir in the documentation is not correct, an 's' is missing: `download/manual` should be `downloads/manual`

Note: [dataset_builder.py#L768](https://github.com/michaelsresearch/datasets/blob/master/tensorflow_datasets/core/dataset_builder.py#L768) seems to be the corresponding code that defines the default dir. 