### PR TITLE
Update tfds.testing.mock_data to not require metadata

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -510,7 +510,6 @@ class DatasetBuilder(registered.RegisteredDataset):
     # pylint: enable=line-too-long
     logging.info("Constructing tf.data.Dataset for split %s, from %s",
                  split, self._data_dir)
-
     if not tf.io.gfile.exists(self._data_dir):
       raise AssertionError(
           ("Dataset %s: could not find data in %s. Please make sure to call "

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -510,13 +510,13 @@ class DatasetBuilder(registered.RegisteredDataset):
     # pylint: enable=line-too-long
     logging.info("Constructing tf.data.Dataset for split %s, from %s",
                  split, self._data_dir)
-    # TODO: Fix or mock this function
-    # if not tf.io.gfile.exists(self._data_dir):
-    #   raise AssertionError(
-    #       ("Dataset %s: could not find data in %s. Please make sure to call "
-    #        "dataset_builder.download_and_prepare(), or pass download=True to "
-    #        "tfds.load() before trying to access the tf.data.Dataset object."
-    #       ) % (self.name, self._data_dir_root))
+
+    if not tf.io.gfile.exists(self._data_dir):
+      raise AssertionError(
+          ("Dataset %s: could not find data in %s. Please make sure to call "
+           "dataset_builder.download_and_prepare(), or pass download=True to "
+           "tfds.load() before trying to access the tf.data.Dataset object."
+          ) % (self.name, self._data_dir_root))
 
     # By default, return all splits
     if split is None:

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -510,12 +510,13 @@ class DatasetBuilder(registered.RegisteredDataset):
     # pylint: enable=line-too-long
     logging.info("Constructing tf.data.Dataset for split %s, from %s",
                  split, self._data_dir)
-    if not tf.io.gfile.exists(self._data_dir):
-      raise AssertionError(
-          ("Dataset %s: could not find data in %s. Please make sure to call "
-           "dataset_builder.download_and_prepare(), or pass download=True to "
-           "tfds.load() before trying to access the tf.data.Dataset object."
-          ) % (self.name, self._data_dir_root))
+    # TODO: Fix or mock this function
+    # if not tf.io.gfile.exists(self._data_dir):
+    #   raise AssertionError(
+    #       ("Dataset %s: could not find data in %s. Please make sure to call "
+    #        "dataset_builder.download_and_prepare(), or pass download=True to "
+    #        "tfds.load() before trying to access the tf.data.Dataset object."
+    #       ) % (self.name, self._data_dir_root))
 
     # By default, return all splits
     if split is None:

--- a/tensorflow_datasets/testing/mocking.py
+++ b/tensorflow_datasets/testing/mocking.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Mock util for tfds.
 """
 

--- a/tensorflow_datasets/testing/mocking_test.py
+++ b/tensorflow_datasets/testing/mocking_test.py
@@ -132,7 +132,7 @@ class MockingTest(test_case.TestCase):
       # Testing Code-Only Mocking Policy
       with mocking.mock_data(
           data_dir=tmp_dir, policy=mocking.MockPolicy.CODE_ONLY):
-        ds = load.load('mnist', split='train')
+        ds = load.load('mnist', split='non_existent')
         self.assertEqual(ds.element_spec, {
             'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
             'label': tf.TensorSpec(shape=(), dtype=tf.int64),
@@ -144,6 +144,14 @@ class MockingTest(test_case.TestCase):
         with self.assertRaisesWithPredicateMatch(
             ValueError, 'TFDS has been mocked'):
           ds = load.load('mnist', split='train')
+
+      with self.assertRaisesWithPredicateMatch(ValueError, 'Unknown split'):
+        ds = load.load('mnist', split='non_existent')
+        self.assertEqual(ds.element_spec, {
+            'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
+            'label': tf.TensorSpec(shape=(), dtype=tf.int64),
+        })
+
 
 if __name__ == '__main__':
   test_utils.test_main()

--- a/tensorflow_datasets/testing/mocking_test.py
+++ b/tensorflow_datasets/testing/mocking_test.py
@@ -120,6 +120,16 @@ class MockingTest(test_case.TestCase):
       )
 
   def test_mocking_policies(self):
+    with mocking.mock_data():
+      ds = load.load('mnist', split='train')
+      self.assertEqual(ds.element_spec, {
+          'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
+          'label': tf.TensorSpec(shape=(), dtype=tf.int64),
+      })
+
+      with self.assertRaisesWithPredicateMatch(ValueError, 'Unknown split'):
+        ds = load.load('mnist', split='non_existent')
+
     with test_utils.tmp_dir() as tmp_dir:
       # Testing Auto Mocking Policy
       with mocking.mock_data(data_dir=tmp_dir):
@@ -130,8 +140,8 @@ class MockingTest(test_case.TestCase):
         })
 
       # Testing Code-Only Mocking Policy
-      with mocking.mock_data(
-          data_dir=tmp_dir, policy=mocking.MockPolicy.CODE_ONLY):
+      with mocking.mock_data(data_dir=tmp_dir,
+                             policy=mocking.MockPolicy.CODE_ONLY):
         ds = load.load('mnist', split='non_existent')
         self.assertEqual(ds.element_spec, {
             'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
@@ -139,18 +149,11 @@ class MockingTest(test_case.TestCase):
         })
 
       # Testing Dir-Only Mocking Policy
-      with mocking.mock_data(
-          data_dir=tmp_dir, policy=mocking.MockPolicy.DIR_ONLY):
+      with mocking.mock_data(data_dir=tmp_dir,
+                             policy=mocking.MockPolicy.DIR_ONLY):
         with self.assertRaisesWithPredicateMatch(
-            ValueError, 'TFDS has been mocked'):
+            ValueError, 'copy the real metadata files'):
           ds = load.load('mnist', split='train')
-
-      with self.assertRaisesWithPredicateMatch(ValueError, 'Unknown split'):
-        ds = load.load('mnist', split='non_existent')
-        self.assertEqual(ds.element_spec, {
-            'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
-            'label': tf.TensorSpec(shape=(), dtype=tf.int64),
-        })
 
 
 if __name__ == '__main__':

--- a/tensorflow_datasets/testing/mocking_test.py
+++ b/tensorflow_datasets/testing/mocking_test.py
@@ -119,6 +119,31 @@ class MockingTest(test_case.TestCase):
           [1, 9, 2, 5, 3],
       )
 
+  def test_mocking_policies(self):
+    with test_utils.tmp_dir() as tmp_dir:
+      # Testing Auto Mocking Policy
+      with mocking.mock_data(data_dir=tmp_dir):
+        ds = load.load('mnist', split='train')
+        self.assertEqual(ds.element_spec, {
+            'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
+            'label': tf.TensorSpec(shape=(), dtype=tf.int64),
+        })
+
+      # Testing Code-Only Mocking Policy
+      with mocking.mock_data(
+          data_dir=tmp_dir, policy=mocking.MockPolicy.CODE_ONLY):
+        ds = load.load('mnist', split='train')
+        self.assertEqual(ds.element_spec, {
+            'image': tf.TensorSpec(shape=(28, 28, 1), dtype=tf.uint8),
+            'label': tf.TensorSpec(shape=(), dtype=tf.int64),
+        })
+
+      # Testing Dir-Only Mocking Policy
+      with mocking.mock_data(
+          data_dir=tmp_dir, policy=mocking.MockPolicy.DIR_ONLY):
+        with self.assertRaisesWithPredicateMatch(
+            ValueError, 'TFDS has been mocked'):
+          ds = load.load('mnist', split='train')
 
 if __name__ == '__main__':
   test_utils.test_main()


### PR DESCRIPTION
Fix https://github.com/tensorflow/datasets/issues/2404
Add mocking policies

TODO:
* [x] Fix `as_dataset` function