### PR TITLE
Fix a typo in the overview docs

### DIFF
--- a/docs/overview.ipynb
+++ b/docs/overview.ipynb
@@ -103,7 +103,7 @@
       "source": [
         "## Find available datasets\n",
         "\n",
-        "All dataset builders are subclass of `tfds.core.DatasetBuilder`. To get the list of available builders, uses `tfds.list_builders()` or look at our [catalog](https://www.tensorflow.org/datasets/catalog/overview)."
+        "All dataset builders are subclass of `tfds.core.DatasetBuilder`. To get the list of available builders, use `tfds.list_builders()` or look at our [catalog](https://www.tensorflow.org/datasets/catalog/overview)."
       ]
     },
     {


### PR DESCRIPTION
This PR fixes a typo in the [overview](https://www.tensorflow.org/datasets/overview) (section Find available datasets) docs. Instead of: ```To get the list of available builders, uses `tfds.list_builders()` ...``` , it should be: ```To get the list of available builders, use `tfds.list_builders()` ...```