### PR TITLE
Add core tab support for checksums

### DIFF
--- a/tensorflow_datasets/core/download/checksums.py
+++ b/tensorflow_datasets/core/download/checksums.py
@@ -151,14 +151,9 @@ def _parse_url_infos(checksums_file: Iterable[str]) -> Dict[str, UrlInfo]:
     if not line or line.startswith('#'):
       continue
     # URL might have spaces inside, but size and checksum will not.
-    url, size, checksum = line.rsplit(' ', 2)
+    url, size, checksum = line.rsplit('\t', 2)
     url_infos[url] = UrlInfo(size=int(size), checksum=checksum)
   return url_infos
-
-
-def url_infos_from_path(checksums_path: str) -> Dict[str, UrlInfo]:
-  with tf.io.gfile.GFile(checksums_path) as f:
-    return _parse_url_infos(f.read().splitlines())
 
 
 @utils.memoize()
@@ -201,4 +196,4 @@ def store_checksums(dataset_name: str, url_infos: Dict[str, UrlInfo]) -> None:
     return
   with tf.io.gfile.GFile(path, 'w') as f:
     for url, url_info in sorted(new_data.items()):
-      f.write('{} {} {}\n'.format(url, url_info.size, url_info.checksum))
+      f.write('{}\t{}\t{}\n'.format(url, url_info.size, url_info.checksum))

--- a/tensorflow_datasets/core/download/checksums.py
+++ b/tensorflow_datasets/core/download/checksums.py
@@ -151,7 +151,10 @@ def _parse_url_infos(checksums_file: Iterable[str]) -> Dict[str, UrlInfo]:
     if not line or line.startswith('#'):
       continue
     # URL might have spaces inside, but size and checksum will not.
-    url, size, checksum = line.rsplit('\t', 2)
+    try:
+      url, size, checksum = line.rsplit('\t', 2)
+    except ValueError:
+      url, size, checksum = line.rsplit(' ', 2)
     url_infos[url] = UrlInfo(size=int(size), checksum=checksum)
   return url_infos
 


### PR DESCRIPTION
PR in reference to Issue #2420
`core/download/checksums.py' has been fixed to now use `tabs` for storage and retrieval of checksums