### PR TITLE
Update Release-Notes

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -72,10 +72,11 @@ class BuilderConfig(object):
   `BuilderConfig` and add their own properties.
   """
 
-  def __init__(self, *, name, version=None, supported_versions=None,
+  def __init__(self, *, name, version=None, release_notes={}, supported_versions=None,
                description=None):
     self._name = name
     self._version = version
+    self._release_notes = release_notes
     self._supported_versions = supported_versions or []
     self._description = description
 
@@ -88,6 +89,10 @@ class BuilderConfig(object):
     return self._version
 
   @property
+  def release_notes(self):
+    return self._release_notes
+
+  @property
   def supported_versions(self):
     return self._supported_versions
 
@@ -96,10 +101,12 @@ class BuilderConfig(object):
     return self._description
 
   def __repr__(self):
-    return "<{cls_name} name={name}, version={version}>".format(
+    return "<{cls_name} name={name}, \
+        version={version}, release_note={release_note}>".format(
         cls_name=type(self).__name__,
         name=self.name,
-        version=self.version or "None")
+        version=self.version or "None",
+        release_note=self.release_notes.get(self.version, "None"))
 
 
 class DatasetBuilder(registered.RegisteredDataset):

--- a/tensorflow_datasets/scripts/cli/new.py
+++ b/tensorflow_datasets/scripts/cli/new.py
@@ -148,6 +148,9 @@ def _create_dataset_file(info: DatasetInfo) -> None:
         """DatasetBuilder for {info.name} dataset."""
 
         VERSION = tfds.core.Version('0.1.0')
+        RELEASE_NOTES = {{
+        '0.1.0': 'Initial release',
+        }}
 
         def _info(self) -> tfds.core.DatasetInfo:
           """Returns the dataset metadata."""

--- a/tensorflow_datasets/scripts/create_new_dataset.py
+++ b/tensorflow_datasets/scripts/create_new_dataset.py
@@ -90,6 +90,9 @@ class {dataset_cls}(tfds.core.GeneratorBasedBuilder):
 
   # {TODO}: Set up version.
   VERSION = tfds.core.Version('0.1.0')
+  RELEASE_NOTES = {
+      '0.1.0': 'Initial release',
+  }
 
   def _info(self):
     # {TODO}: Specifies the tfds.core.DatasetInfo object

--- a/tensorflow_datasets/scripts/create_new_dataset.py
+++ b/tensorflow_datasets/scripts/create_new_dataset.py
@@ -88,7 +88,7 @@ _DATASET_DEFAULTS = """\
 class {dataset_cls}(tfds.core.GeneratorBasedBuilder):
   \"""{TODO}: Short description of my dataset.\"""
 
-  # {TODO}: Set up version.
+  # {TODO}: Set up version and release notes.
   VERSION = tfds.core.Version('0.1.0')
   RELEASE_NOTES = {
       '0.1.0': 'Initial release',


### PR DESCRIPTION
In reference to Issue #2463 
Release notes have been updated in the `create_dataset.py` and the `cli/new.py` file.
A separate `release_notes` variable has been added to the `BuilderConfig`