### PR TITLE
CBIS-DDSM: fix random patch cropping minimum position (min_x, min_y)

### DIFF
--- a/tensorflow_datasets/image_classification/cbis_ddsm.py
+++ b/tensorflow_datasets/image_classification/cbis_ddsm.py
@@ -709,8 +709,8 @@ def _sample_positive_patches(image,
     # Determine the region where random samples should be sampled from.
     max_h, min_h = max(abnorm_h, patch_size[0]), min(abnorm_h, patch_size[0])
     max_w, min_w = max(abnorm_w, patch_size[1]), min(abnorm_w, patch_size[1])
-    min_y = abnorm_y - int(max_h - min_h) - int((1.0 - min_overlap_threshold) * min_h)
-    min_x = abnorm_x - int(max_w - min_w) - int((1.0 - min_overlap_threshold) * min_w)
+    min_y = abnorm_y - max_h + min_overlap_threshold * min_h
+    min_x = abnorm_x - max_w + min_overlap_threshold * min_w
     max_y = abnorm_y + abnorm_h - int(min_overlap_threshold * min_h)
     max_x = abnorm_x + abnorm_w - int(min_overlap_threshold * min_w)
     # Ensure that all sampled batches are within the image.

--- a/tensorflow_datasets/image_classification/cbis_ddsm.py
+++ b/tensorflow_datasets/image_classification/cbis_ddsm.py
@@ -709,8 +709,8 @@ def _sample_positive_patches(image,
     # Determine the region where random samples should be sampled from.
     max_h, min_h = max(abnorm_h, patch_size[0]), min(abnorm_h, patch_size[0])
     max_w, min_w = max(abnorm_w, patch_size[1]), min(abnorm_w, patch_size[1])
-    min_y = abnorm_y - int((1.0 - min_overlap_threshold) * max_h)
-    min_x = abnorm_x - int((1.0 - min_overlap_threshold) * max_w)
+    min_y = abnorm_y - int(max_h - min_h) - int((1.0 - min_overlap_threshold) * min_h)
+    min_x = abnorm_x - int(max_w - min_w) - int((1.0 - min_overlap_threshold) * min_w)
     max_y = abnorm_y + abnorm_h - int(min_overlap_threshold * min_h)
     max_x = abnorm_x + abnorm_w - int(min_overlap_threshold * min_w)
     # Ensure that all sampled batches are within the image.


### PR DESCRIPTION
## Description

There was an issue in the calculation of the minimum position (x,y) that a patch can be sampled from, causing all the abnormalities to be located in the upper-left corner of the patch. It also lead to the creation of several patches with size smaller than the indicated (224,224).
  
## Checklist
* [x] Run `download_and_prepare` successfully 

@jpuigcerver 
