### PR TITLE
Replacing description with RELEASE_NOTES

### DIFF
--- a/tensorflow_datasets/core/utils/version.py
+++ b/tensorflow_datasets/core/utils/version.py
@@ -57,13 +57,13 @@ class Version(object):
       Experiment.DUMMY: False,
   }
 
-  def __init__(self, version_str, description=None, experiments=None,
+  def __init__(self, version_str, RELEASE_NOTES=None, experiments=None,
                tfds_version_to_prepare=None):
     """Version init.
 
     Args:
       version_str: string. Eg: "1.2.3".
-      description: string, a description of what is new in this version.
+      RELEASE_NOTES: dict of versions with their release notes.
       experiments: dict of experiments. See Experiment.
       tfds_version_to_prepare: string, defaults to None. If set, indicates that
         current version of TFDS cannot be used to `download_and_prepare` the
@@ -73,7 +73,7 @@ class Version(object):
     if description is not None and not isinstance(description, str):
       raise TypeError(
           "Description should be a string. Got {}".format(description))
-    self.description = description
+    self.RELEASE_NOTES = RELEASE_NOTES
     self._experiments = self._DEFAULT_EXPERIMENTS.copy()
     self.tfds_version_to_prepare = tfds_version_to_prepare
     if experiments:

--- a/tensorflow_datasets/core/utils/version.py
+++ b/tensorflow_datasets/core/utils/version.py
@@ -70,9 +70,10 @@ class Version(object):
         dataset, but that TFDS at version {tfds_version_to_prepare} should be
         used instead.
     """
-    if description is not None and not isinstance(description, str):
+    if RELEASE_NOTES is not None and not isinstance(RELEASE_NOTES, dict):
       raise TypeError(
-          "Description should be a string. Got {}".format(description))
+          "RELEASE NOTES should be a dictionary. Got a {}: {}".format(
+           type(RELEASE_NOTES), RELEASE_NOTES))
     self.RELEASE_NOTES = RELEASE_NOTES
     self._experiments = self._DEFAULT_EXPERIMENTS.copy()
     self.tfds_version_to_prepare = tfds_version_to_prepare

--- a/tensorflow_datasets/core/utils/version.py
+++ b/tensorflow_datasets/core/utils/version.py
@@ -63,16 +63,16 @@ class Version(object):
 
     Args:
       version_str: string. Eg: "1.2.3".
-      RELEASE_NOTES: dict of versions with their release notes.
+      RELEASE_NOTES: Release note of the specified version.
       experiments: dict of experiments. See Experiment.
       tfds_version_to_prepare: string, defaults to None. If set, indicates that
         current version of TFDS cannot be used to `download_and_prepare` the
         dataset, but that TFDS at version {tfds_version_to_prepare} should be
         used instead.
     """
-    if RELEASE_NOTES is not None and not isinstance(RELEASE_NOTES, dict):
+    if RELEASE_NOTES is not None and not isinstance(RELEASE_NOTES, str):
       raise TypeError(
-          "RELEASE NOTES should be a dictionary. Got a {}: {}".format(
+          "RELEASE NOTES should be a str. Got a {}: {}".format(
            type(RELEASE_NOTES), RELEASE_NOTES))
     self.RELEASE_NOTES = RELEASE_NOTES
     self._experiments = self._DEFAULT_EXPERIMENTS.copy()


### PR DESCRIPTION
* Issue Reference: #2463 
The `description='release_notes` field has been replaced by `RELEASE_NOTES` in `Version(description=)`
