### PR TITLE
Remove dependency on dm-tree 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,7 @@
         "**/__pycache__": true,
         "**/.pytest_cache": true,
         "**/*.egg-info": true
-    }
+    },
+    "python.linting.flake8Enabled": false,
+    "python.pythonPath": "/home/alex/.pyenv/versions/3.7.4/bin/python"
 }

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ REQUIRED_PKGS = [
     'absl-py',
     'attrs>=18.1.0',
     'dill',  # TODO(tfds): move to TESTS_REQUIRE.
-    'dm-tree',
     'future',
     'numpy',
     'promise',

--- a/tensorflow_datasets/core/as_dataframe.py
+++ b/tensorflow_datasets/core/as_dataframe.py
@@ -18,7 +18,6 @@
 
 import typing
 from typing import Callable, Dict, List, Optional, Tuple
-import collections
 
 import dataclasses
 import numpy as np
@@ -29,6 +28,7 @@ from tensorflow_datasets.core import dataset_utils
 from tensorflow_datasets.core import features
 from tensorflow_datasets.core import lazy_imports_lib
 from tensorflow_datasets.core.utils.type_utils import TreeDict
+from tensorflow_datasets.core.utils.py_utils import _flatten, _flatten_with_path
 
 try:
   import pandas  # pylint: disable=g-import-not-at-top
@@ -139,31 +139,6 @@ class StyledDataFrame(DataFrame):
       return super()._repr_html_()
     return self.__styler._repr_html_()  # pylint: disable=protected-access
 
-
-def _flatten_with_path(structure: TreeDict):
-  """Convert a TreeDict into a flat list of paths and their values
-
-  A path is a list of keys to get to the value
-  Yields the result elements instead of creating a list
-  """
-  if isinstance(structure, collections.Mapping):
-    for key in sorted(structure):
-      for sub_path, sub_value in _flatten_with_path(structure[key]):
-        yield [key] + sub_path, sub_value
-  else:
-    yield [], structure
-
-def _flatten(structure: TreeDict):
-  """Convert a TreeDict into a flat list of values without the keys
-
-  Yields the result elements instead of creating a list
-  """
-  if isinstance(structure, collections.Mapping):
-    for key in sorted(structure):
-      for sub_value in _flatten(structure[key]):
-        yield sub_value
-  else:
-    yield structure
 
 def _make_columns(
     specs: TreeDict[tf.TypeSpec],

--- a/tensorflow_datasets/core/as_dataframe_test.py
+++ b/tensorflow_datasets/core/as_dataframe_test.py
@@ -37,53 +37,6 @@ def _as_df(ds_name: str, **kwargs) -> pandas.DataFrame:
   return df
 
 
-def test_flatten_with_path():
-  """Test that the flatten function works as expected"""
-  from from tensorflow_datasets.core.as_dataframe import _flatten_with_path
-  assert list(_flatten_with_path('value')) == [([], 'value')]
-  assert list(_flatten_with_path({'key': 'value'})) == [('key', 'value')]
-  assert list(_flatten_with_path({'key1': 'value', 'key2': 'value2'})) == [
-    ('key1', 'value'),
-    ('key2', 'value2'),
-  ]
-  complex_dict = {
-    'key': 'value',
-    'nested': {
-      'sub_key': 'subvalue',
-      'sub_nested': {
-        'subsubkey1': 'subsubvalue1',
-        'subsubkey2': 'subsubvalue2',
-      },
-      'key2': 'value2',
-    }
-  }
-  assert list(_flatten_with_path(complex_dict)) == [
-    (['key'], 'value'),
-    (['key2'], 'value2'),
-    (['nested', 'subkey'], 'subvalue'),
-    (['nested', 'sub_nested', 'subsubkey1'], 'subsubvalue1'),
-    (['nested', 'sub_nested', 'subsubkey2'], 'subsubvalue2'),
-  ]
-
-def test_flatten():
-  """Test that the flatten function works as expected"""
-  from from tensorflow_datasets.core.as_dataframe import _flatten
-  assert list(_flatten('value')) == ['value']
-  assert list(_flatten({'key': 'value'})) == ['value']
-  assert list(_flatten({'key1': 'value', 'key2': 'value2'})) == ['value', 'value2']
-  complex_dict = {
-    'key': 'value',
-    'nested': {
-      'sub_key': 'subvalue',
-      'sub_nested': {
-        'subsubkey1': 'subsubvalue1',
-        'subsubkey2': 'subsubvalue2',
-      },
-      'key2': 'value2',
-    }
-  }
-  assert list(_flatten(complex_dict)) == ['value', 'value2', 'subvalue', 'subsubvalue1', 'subsubvalue2']
-
 def test_as_dataframe():
   """Tests that as_dataframe works without the `tfds.core.DatasetInfo`."""
   ds = tf.data.Dataset.from_tensor_slices(

--- a/tensorflow_datasets/core/as_dataframe_test.py
+++ b/tensorflow_datasets/core/as_dataframe_test.py
@@ -37,6 +37,53 @@ def _as_df(ds_name: str, **kwargs) -> pandas.DataFrame:
   return df
 
 
+def test_flatten_with_path():
+  """Test that the flatten function works as expected"""
+  from from tensorflow_datasets.core.as_dataframe import _flatten_with_path
+  assert list(_flatten_with_path('value')) == [([], 'value')]
+  assert list(_flatten_with_path({'key': 'value'})) == [('key', 'value')]
+  assert list(_flatten_with_path({'key1': 'value', 'key2': 'value2'})) == [
+    ('key1', 'value'),
+    ('key2', 'value2'),
+  ]
+  complex_dict = {
+    'key': 'value',
+    'nested': {
+      'sub_key': 'subvalue',
+      'sub_nested': {
+        'subsubkey1': 'subsubvalue1',
+        'subsubkey2': 'subsubvalue2',
+      },
+      'key2': 'value2',
+    }
+  }
+  assert list(_flatten_with_path(complex_dict)) == [
+    (['key'], 'value'),
+    (['key2'], 'value2'),
+    (['nested', 'subkey'], 'subvalue'),
+    (['nested', 'sub_nested', 'subsubkey1'], 'subsubvalue1'),
+    (['nested', 'sub_nested', 'subsubkey2'], 'subsubvalue2'),
+  ]
+
+def test_flatten():
+  """Test that the flatten function works as expected"""
+  from from tensorflow_datasets.core.as_dataframe import _flatten
+  assert list(_flatten('value')) == ['value']
+  assert list(_flatten({'key': 'value'})) == ['value']
+  assert list(_flatten({'key1': 'value', 'key2': 'value2'})) == ['value', 'value2']
+  complex_dict = {
+    'key': 'value',
+    'nested': {
+      'sub_key': 'subvalue',
+      'sub_nested': {
+        'subsubkey1': 'subsubvalue1',
+        'subsubkey2': 'subsubvalue2',
+      },
+      'key2': 'value2',
+    }
+  }
+  assert list(_flatten(complex_dict)) == ['value', 'value2', 'subvalue', 'subsubvalue1', 'subsubvalue2']
+
 def test_as_dataframe():
   """Tests that as_dataframe works without the `tfds.core.DatasetInfo`."""
   ds = tf.data.Dataset.from_tensor_slices(

--- a/tensorflow_datasets/core/as_dataframe_test.py
+++ b/tensorflow_datasets/core/as_dataframe_test.py
@@ -97,6 +97,7 @@ def test_as_dataframe():
   df = as_dataframe.as_dataframe(ds)
   assert isinstance(df, pandas.DataFrame)
   assert df._repr_html_().startswith('<style')
+  assert list(df.columns) == ['nested/sub1', 'some_key']
 
 
 def test_text_dataset():

--- a/tensorflow_datasets/core/utils/py_utils.py
+++ b/tensorflow_datasets/core/utils/py_utils.py
@@ -209,16 +209,8 @@ def zip_nested(arg0, *args, **kwargs):
 
 
 def _flatten(structure: TreeDict):
-  """Convert a TreeDict into a flat list of values without the keys
-
-  Yields the result elements instead of creating a list
-  """
-  if isinstance(structure, collections.abc.Mapping):
-    for key in sorted(structure):
-      for sub_value in _flatten(structure[key]):
-        yield sub_value
-  else:
-    yield structure
+  """Convert a TreeDict into a flat list of values without the keys"""
+  return tf.nest.flatten(structure)
 
 
 def _flatten_with_path(structure: TreeDict):


### PR DESCRIPTION
As discussed in https://github.com/tensorflow/datasets/issues/2252#issuecomment-692589592 using dm-tree is problematic due to its usage of Bazel to build itself on architectures where it is not available as a binary package.

As only 2 functions are used which are very similar and pretty easy to implement this is done here, tests added and used by the 2 other functions.