### PR TITLE
Fix GCS support for looking up existing versions

### DIFF
--- a/tensorflow_datasets/core/utils/version.py
+++ b/tensorflow_datasets/core/utils/version.py
@@ -170,6 +170,12 @@ def list_all_versions(root_dir: str) -> List[Version]:
   if not tf.io.gfile.exists(root_dir):
     return []
 
+  paths = tf.io.gfile.listdir(root_dir)
+
+  # Strip trailing slash if listing a GCS bucket.
+  if root_dir.startswith("gs://"):
+    paths = [path.rstrip("/") for path in paths]
+
   return sorted(  # Return all versions
-      Version(v) for v in tf.io.gfile.listdir(root_dir) if Version.is_valid(v)
+      Version(v) for v in paths if Version.is_valid(v)
   )


### PR DESCRIPTION
I was super excited to see that TFDS 4 doesn't need the dataset builder class available when consuming datasets, but it doesn't work on 4.0.0 when `data_dir` is a GCS bucket. There are two bugs. I'm fixing the first one in this PR and I'm also working on the other one in a subsequent PR today.

When `tf.io.gfile.listdir(root_dir)` is called on a "gs://..." path, each list element will have a trailing slash and the subsequent `Version.is_valid` call will return False, meaning even if there are working versions in the bucket, they won't be discovered properly. This PR fixes that by stripping the trailing slashes if the root_dir is a GCS path.

## Discussion point
Perhaps the new `startswith` check should be removed so we just simply always remove trailing slashes in case they exist. Thoughts?