### PR TITLE
Make sure tfds.load supports loading datasets from GCS without the builder class imported

### DIFF
--- a/tensorflow_datasets/core/load.py
+++ b/tensorflow_datasets/core/load.py
@@ -332,9 +332,8 @@ def load(
   """
   # pylint: enable=line-too-long
 
-  name, name_builder_kwargs = _dataset_name_and_kwargs_from_name_str(name)
-  name_builder_kwargs.update(builder_kwargs or {})
-  builder_kwargs = name_builder_kwargs
+  if builder_kwargs is None:
+    builder_kwargs = {}
 
   # Set data_dir
   if try_gcs and gcs_utils.is_dataset_on_gcs(name):


### PR DESCRIPTION
Background: https://github.com/tensorflow/datasets/pull/2551

The other bug I found for getting TFDS 4 to support a GCS data_dir.

`tfds.builder` assumes that the `name` string contains a config and version when the dataset builder class is missing. Unfortunately, `tfds.load` mutates `name` and removes config and version before calling the builder, so no existing versions will be discovered when the class is missing, even when they actually do exist.

I'm curious if my thinking is right on this, because there should already be some test case covering this behavior, I assume?