### PR TITLE
added verify to DownloadConfig/Manager

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -796,6 +796,7 @@ class DatasetBuilder(registered.RegisteredDataset):
         force_extraction=(download_config.download_mode == FORCE_REDOWNLOAD),
         force_checksums_validation=download_config.force_checksums_validation,
         register_checksums=download_config.register_checksums,
+        verify=download_config.verify,
     )
 
   @property

--- a/tensorflow_datasets/core/download/download_manager.py
+++ b/tensorflow_datasets/core/download/download_manager.py
@@ -73,6 +73,7 @@ class DownloadConfig(object):
       beam_runner=None,
       beam_options=None,
       try_download_gcs=True,
+      verify=True,
   ):
     """Constructs a `DownloadConfig`.
 
@@ -99,6 +100,8 @@ class DownloadConfig(object):
       try_download_gcs: `bool`, defaults to True. If True, prepared dataset
         will be downloaded from GCS, when available. If False, dataset will be
         downloaded and prepared from scratch.
+      verify: `bool`, defaults to True. Controls whether we verify server TLS
+        certificates.
     """
     self.extract_dir = extract_dir
     self.manual_dir = manual_dir
@@ -112,6 +115,7 @@ class DownloadConfig(object):
     self.beam_runner = beam_runner
     self.beam_options = beam_options
     self.try_download_gcs = try_download_gcs
+    self.verify = verify
 
 
 class DownloadManager(object):
@@ -175,6 +179,7 @@ class DownloadManager(object):
       force_extraction: bool = False,
       force_checksums_validation: bool = False,
       register_checksums: bool = False,
+      verify: bool = True,
   ):
     """Download manager constructor.
 
@@ -193,6 +198,7 @@ class DownloadManager(object):
         have checksums.
       register_checksums: If True, dl checksums aren't
         checked, but stored into file.
+      verify: If False, TLS certificates are not verified.
     """
     self._dataset_name = dataset_name
     self._download_dir = os.path.expanduser(download_dir)
@@ -206,6 +212,7 @@ class DownloadManager(object):
     self._force_extraction = force_extraction
     self._force_checksums_validation = force_checksums_validation
     self._register_checksums = register_checksums
+    self._verify = verify
 
     # All known URLs: {url: UrlInfo(size=, checksum=)}
     self._url_infos = checksums.get_all_url_infos()
@@ -480,7 +487,8 @@ class DownloadManager(object):
           url_path=url_path,
           url_info=url_info,
       )
-    return self._downloader.download(url, download_dir_path).then(callback)
+    return self._downloader.download(url, download_dir_path,
+                                     self._verify).then(callback)
 
   @utils.build_synchronize_decorator()
   @utils.memoize()


### PR DESCRIPTION
Previous versions of tfds (< 3.0 ?) allowed downloading from servers with invalid TLS certificates, but this is no longer the case, invalidating some existing external `DatasetBuilder`s. This PR allows users to specify `verify=False` in `DownloadConfig` to get around this requirement.

The following demonstrates an existing external package which can upgrade to recent `tfds` versions because with this PR applied.

```bash
pip install tensorflow-graphics --no-deps
```

```python
import tensorflow_datasets as tfds
import tensorflow_graphics.datasets.modelnet40 # pylint: disable=unused-import

builder = tfds.builder('model_net40')
config = tfds.core.download.DownloadConfig(verify=False)
builder.download_and_prepare(download_config=config)
```