### PR TITLE
change emnist/letter class to 26 from 37

### DIFF
--- a/docs/add_dataset.md
+++ b/docs/add_dataset.md
@@ -457,3 +457,11 @@ Run the following command to test the dataset.
 ```sh
 python my_dataset_test.py
 ```
+
+## Send us feedback
+
+We are continously trying to improve the dataset creation workflow, but can only
+do so if we are aware of the issues. Which issues, errors did you encountered
+while creating the dataset ? Was there a part which was confusing, boilerplate
+or wasn't working the first time ? Please share your
+[feedback on github](https://github.com/tensorflow/datasets/issues).


### PR DESCRIPTION
# Add Dataset

* Dataset Name: <Emnist>
* Issue Reference: #2570
* `dataset_info.json` Gist: <link>
  
## Description
The original Emnist/Letters data set has 26 classes but in the Docs it is marked as having 37 classes. This PR is an improvement to the original docs

<description>
  
## Checklist
* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
