### PR TITLE
Update on mnist.py

### DIFF
--- a/tensorflow_datasets/image_classification/mnist.py
+++ b/tensorflow_datasets/image_classification/mnist.py
@@ -264,7 +264,7 @@ class EMNIST(MNIST):
       ),
       EMNISTConfig(
           name="letters",
-          class_number=37,
+          class_number=26,
           train_examples=88800,
           test_examples=14800,
           description="EMNIST Letters",


### PR DESCRIPTION

* Dataset Name:  EMNIST Letters
* Issue Reference:  #2579
* `dataset_info.json` Gist:  
https://www.nist.gov/itl/products-and-services/emnist-dataset
https://github.com/tensorflow/datasets/issues/2579
code:  ***
EMNISTConfig(
          name="letters",
          class_number=37,
          train_examples=88800,
          test_examples=14800,
          description="EMNIST Letters",
      ),
***
  
## Description
EMNIST letters dataset contain 26  class, not 37 I have checked it with the Original NIST Website while loadingit shows 37 num_class
  
## Checklist
* [x] Address all TODO's
* [x] Add alphabetized import to subdirectory's `__init__.py`
* [x] Run `download_and_prepare` successfully
* [x] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [x] Properly cite in `BibTeX` format
* [x] Add passing test(s)
* [x] Add test data
* [x] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [x] Add data generation script (if applicable)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
