### PR TITLE
Pathlib interface for tf.io.gfile - GcsPath

### DIFF
--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -80,29 +80,6 @@ class GcsPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
     """Opens the file."""
     return tf.io.gfile.GFile(str(self), mode, **kwargs)
 
-  def read_bytes(self) -> bytes:
-    """Reads contents of self as bytes."""
-    with tf.io.gfile.GFile(self._get_path_str(), 'rb') as f:
-      return f.read()
-
-  def read_text(self, encoding: Optional[str] = None) -> str:
-    """Reads contents of self as str."""
-    with tf.io.gfile.GFile(self._get_path_str(), 'r') as f:
-      return f.read()
-
-  def write_bytes(self, data: bytes) -> None:
-    """Writes content as bytes."""
-    with tf.io.gfile.GFile(self._get_path_str(), 'wb') as f:
-      return f.write(data)
-
-  def write_text(self,
-                 data: str,
-                 encoding: Optional[str] = None,
-                 errors: Optional[str] = None) -> None:
-    """Writes content as str."""
-    with tf.io.gfile.GFile(self._get_path_str(), 'w') as f:
-      return f.write(data)
-
   def rename(self, target: type_utils.PathLike) -> None:
     """Rename file or directory to the given target """
     tf.io.gfile.rename(self._get_path_str(), target)

--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -123,4 +123,4 @@ class GcsPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
 
   def replace(self, target) -> None:
     """Replace file or directory to the given target """
-    tf.io.gfile.rename(str(self), target, overwrite=True)
+    # TODO: tf.io.gfile.rename(str(self), target, overwrite=True)

--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -86,5 +86,4 @@ class GcsPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
 
   def replace(self, target: type_utils.PathLike) -> None:
     """Replace file or directory to the given target """
-    # TODO: tf.io.gfile.rename(self._get_path_str(), target, overwrite=True)
-
+    tf.io.gfile.rename(self._get_path_str(), target, overwrite=True)

--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -1,0 +1,117 @@
+"""GPath wrapper around the gfile API"""
+
+import os
+import pathlib
+import typing
+from typing import Union, Iterator, Optional, Any, AnyStr
+import tensorflow as tf
+from tensorflow_datasets.core.utils import type_utils
+
+PathArg = Union[str, pathlib.Path, 'GPath']
+
+
+class GPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
+
+  def __new__(cls, *parts: PathArg):
+    if not parts:
+      return pathlib.Path()
+    full_path = '/'.join(parts)
+    if full_path.startswith(('gs://')):
+      return super().__new__(cls, full_path.replace('gs://', '/gs/', 1))
+    if full_path.startswith(('/gs/')):
+      return super().__new__(cls, *parts)
+    else:
+      return pathlib.Path(*parts)
+
+  def __fpath__(self) -> str:
+    return str(self)
+
+  def __str__(self) -> str:
+    value = super().__str__()
+    if value.startswith('/gs/'):
+      return value.replace('/gs/', 'gs://', 1)
+    return value
+
+  def exists(self) -> bool:
+    return tf.io.gfile.exists(str(self))
+
+  def iterdir(self) -> Iterator['GPath']:
+    for f in tf.io.gfile.listdir(self):
+      yield GPath(f)
+
+  def is_dir(self) -> bool:
+    """Returns True if self is a directory."""
+    return tf.io.gfile.isdir(self)
+
+  def glob(self, pattern: str) -> Iterator['GPath']:
+    """Yielding all matching files (of any kind)."""
+    # Might be able to implement using `iterdir` (recursivelly for `rglob`).
+    path = os.path.join(str(self), pattern)
+
+    for f in tf.io.gfile.glob(str(path)):
+      yield GPath(f)
+
+  def mkdir(
+      self,
+      mode: int = 0o777,
+      parents: bool = False,
+      exist_ok: bool = False,
+  ) -> None:
+    """Create a new directory at this given path."""
+    if self.exists() and not exist_ok:
+      raise FileExistsError(f'{str(self)} already exists.')
+
+    if not self.is_dir():
+      raise NotADirectoryError(f'{str(self)} is not a directory.')
+
+    if parents:
+      tf.io.gfile.makedirs(str(self))
+    else:
+      tf.io.gfile.mkdir(str(self))
+
+
+  def open(
+      self,
+      mode: str = 'r',
+      encoding: Optional[str] = None,
+      errors: Optional[str] = None,
+      **kwargs: Any,
+  ) -> typing.IO[AnyStr]:
+    """Opens the file."""
+    return tf.io.gfile.GFile(self, mode)
+
+  def read_bytes(self) -> bytes:
+    """Reads contents of self as bytes."""
+    with tf.io.gfile.GFile(str(self), 'rb') as f:
+      return f.read()
+
+  def read_text(self, encoding: Optional[str] = None) -> str:
+    """Reads contents of self as str."""
+    with tf.io.gfile.GFile(str(self), 'r') as f:
+      return f.read()
+
+  def write_bytes(self, data: bytes) -> None:
+    """Writes content as bytes."""
+    with tf.io.gfile.GFile(str(self), 'wb') as f:
+      return f.write(data)
+
+
+  def write_text(self,
+                 data: str,
+                 encoding: Optional[str] = None,
+                 errors: Optional[str] = None) -> None:
+    """Writes content as str."""
+    with tf.io.gfile.GFile(str(self), 'w') as f:
+      return f.write(data)
+
+
+
+if __name__ == '__main__':
+
+  PATH = "gs://tfds-data/datasets/mnist/3.0.0/"
+
+  gpath = GPath(PATH)
+  print(gpath.exists())
+
+  f = gpath.glob("*json")
+  print(list(f))

--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -14,7 +14,6 @@ PathArg = Union[str, pathlib.Path, 'GcsPath']
 
 class GcsPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
   """Pathlib like api of tf.io.gfile"""
-
   def __new__(cls, *parts: type_utils.PathLike):
     full_path = '/'.join(os.fspath(p) for p in parts)
     if full_path.startswith(('gs://')):
@@ -41,10 +40,12 @@ class GcsPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
 
 
   def exists(self) -> bool:
+    """Returns True if self exists."""
     return tf.io.gfile.exists(str(self))
 
 
   def iterdir(self) -> Iterator['GcsPath']:
+    """Iterates over the directory."""
     for f in tf.io.gfile.listdir(str(self)):
       yield GcsPath(f)
 

--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -1,55 +1,65 @@
-"""GPath wrapper around the gfile API"""
+"""GcsPath wrapper around the gfile API"""
 
 import os
 import pathlib
 import typing
-from typing import Union, Iterator, Optional, Any, AnyStr
+from typing import Any, AnyStr, Iterator, Optional, Union
+
 import tensorflow as tf
+
 from tensorflow_datasets.core.utils import type_utils
 
-PathArg = Union[str, pathlib.Path, 'GPath']
+PathArg = Union[str, pathlib.Path, 'GcsPath']
 
 
-class GPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
+class GcsPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
+  """Pathlib like api of tf.io.gfile"""
 
-  def __new__(cls, *parts: PathArg):
-    if not parts:
-      return pathlib.Path()
-    full_path = '/'.join(parts)
+  def __new__(cls, *parts: type_utils.PathLike):
+    full_path = '/'.join(os.fspath(p) for p in parts)
     if full_path.startswith(('gs://')):
       return super().__new__(cls, full_path.replace('gs://', '/gs/', 1))
     if full_path.startswith(('/gs/')):
       return super().__new__(cls, *parts)
     else:
-      return pathlib.Path(*parts)
+      raise ValueError('Invalid path')
 
-  def __fpath__(self) -> str:
-    return str(self)
 
-  def __str__(self) -> str:
+  def _get_path_str(self) -> str:
     value = super().__str__()
     if value.startswith('/gs/'):
       return value.replace('/gs/', 'gs://', 1)
-    return value
+    return value  # TODO: Could cache the value
+
+
+  def __fpath__(self) -> str:
+    return self._get_path_str()
+
+
+  def __str__(self) -> str:
+    return self._get_path_str()
+
 
   def exists(self) -> bool:
     return tf.io.gfile.exists(str(self))
 
-  def iterdir(self) -> Iterator['GPath']:
-    for f in tf.io.gfile.listdir(self):
-      yield GPath(f)
+
+  def iterdir(self) -> Iterator['GcsPath']:
+    for f in tf.io.gfile.listdir(str(self)):
+      yield GcsPath(f)
+
 
   def is_dir(self) -> bool:
     """Returns True if self is a directory."""
-    return tf.io.gfile.isdir(self)
+    return tf.io.gfile.isdir(str(self))
 
-  def glob(self, pattern: str) -> Iterator['GPath']:
+
+  def glob(self, pattern: str) -> Iterator['GcsPath']:
     """Yielding all matching files (of any kind)."""
-    # Might be able to implement using `iterdir` (recursivelly for `rglob`).
     path = os.path.join(str(self), pattern)
-
     for f in tf.io.gfile.glob(str(path)):
-      yield GPath(f)
+      yield GcsPath(f)
+
 
   def mkdir(
       self,
@@ -60,9 +70,6 @@ class GPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
     """Create a new directory at this given path."""
     if self.exists() and not exist_ok:
       raise FileExistsError(f'{str(self)} already exists.')
-
-    if not self.is_dir():
-      raise NotADirectoryError(f'{str(self)} is not a directory.')
 
     if parents:
       tf.io.gfile.makedirs(str(self))
@@ -78,17 +85,20 @@ class GPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
       **kwargs: Any,
   ) -> typing.IO[AnyStr]:
     """Opens the file."""
-    return tf.io.gfile.GFile(self, mode)
+    return tf.io.gfile.GFile(str(self), mode, **kwargs)
+
 
   def read_bytes(self) -> bytes:
     """Reads contents of self as bytes."""
     with tf.io.gfile.GFile(str(self), 'rb') as f:
       return f.read()
 
+
   def read_text(self, encoding: Optional[str] = None) -> str:
     """Reads contents of self as str."""
     with tf.io.gfile.GFile(str(self), 'r') as f:
       return f.read()
+
 
   def write_bytes(self, data: bytes) -> None:
     """Writes content as bytes."""
@@ -105,13 +115,11 @@ class GPath(pathlib.PurePosixPath, type_utils.ReadWritePath):
       return f.write(data)
 
 
+  def rename(self, target) -> None:
+    """Rename file or directory to the given target """
+    tf.io.gfile.rename(str(self), target)
 
-if __name__ == '__main__':
 
-  PATH = "gs://tfds-data/datasets/mnist/3.0.0/"
-
-  gpath = GPath(PATH)
-  print(gpath.exists())
-
-  f = gpath.glob("*json")
-  print(list(f))
+  def replace(self, target) -> None:
+    """Replace file or directory to the given target """
+    tf.io.gfile.rename(str(self), target, overwrite=True)

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -2,10 +2,11 @@
 
 import os
 import pathlib
+from pathlib import Path
 
 import pytest
 import tensorflow as tf
-from pathlib import Path
+
 from tensorflow_datasets import testing
 from tensorflow_datasets.core.utils.gpath import GcsPath
 
@@ -22,7 +23,7 @@ def mocked_gfile_path(tmp_path: pathlib.Path):
       listdir=lambda p: os.listdir(_norm_path(p)),
       GFile=lambda p, *args, **kwargs: open(_norm_path(p), *args, **kwargs),
       rename=lambda p1, p2: os.rename(_norm_path(p1), _norm_path(p2)),
-      replace=lambda p1, p2, **kwargs: os.replace(_norm_path(p1), _norm_path(p2), **kwargs),
+      replace=lambda p1, p2: os.replace(_norm_path(p1), _norm_path(p2)), # TODO: tf.io.gfile.rename() overwrite=True
       mkdir=lambda p: os.mkdir(_norm_path(p)),
       makedirs=lambda p: os.makedirs(_norm_path(p)),
       glob=lambda p: Path(_norm_path(p)).parent.glob(Path(_norm_path(p)).stem)  # TODO: temporary func
@@ -103,10 +104,9 @@ def test_rename_replace(mocked_gfile_path: pathlib.Path):
   assert mocked_gfile_path.joinpath('foo.py').exists()
 
   # Rename()
-  # target_path = GcsPath('gs://foo.py')
   src_path.rename('gs://bar.py')
-  # target = GcsPath(mocked_gfile_path.joinpath())
-  # GcsPath(mocked_gfile_path.joinpath('foo.py')).rename('bar.py')
 
   assert not mocked_gfile_path.joinpath('foo.py').exists()
   assert mocked_gfile_path.joinpath('bar.py').exists()
+
+  # Replace() TODO:

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -30,12 +30,32 @@ def mocked_gfile_path(tmp_path: pathlib.Path):
   ):
     yield tmp_path
 
+def test_representations(mocked_gfile_path: pathlib.Path):
+  g_path = GcsPath('gs://bucket/dir')
+
+  assert isinstance(g_path, GcsPath)
+  assert isinstance(g_path.joinpath('file.py').parent, GcsPath)
+  assert str(g_path) == 'gs://bucket/dir'
+  assert os.fspath(g_path) == 'gs://bucket/dir'
+
+
+  with pytest.raises(ValueError, match='Invalid path'):
+    GcsPath('/bucket/dir')
+
 
 def test_gfs(mocked_gfile_path: pathlib.Path):
-  g_path = GcsPath('gs://bucket/dir')
-  assert not g_path.exists()
+  # touch()
+
+  touch_path = GcsPath('gs://touch.txt')
+  assert not touch_path.exists()
+
+  touch_path.touch()
+  assert touch_path.exists()
+  assert mocked_gfile_path.joinpath('touch.txt').exists()
 
   # mkdir()
+  g_path = GcsPath('gs://bucket/dir')
+  assert not g_path.exists()
   g_path.mkdir(parents=True)
 
   # exists()
@@ -94,6 +114,10 @@ def test_mkdir(mocked_gfile_path: pathlib.Path):
 
   g_path.mkdir()
   assert g_path.exists()
+
+  with pytest.raises(FileExistsError, match='already exists'):
+    g_path.mkdir()
+
   assert mocked_gfile_path.joinpath('bucket').exists()
 
 

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -107,14 +107,17 @@ def test_read_write(mocked_gfile_path: pathlib.Path):
     f.write(b'abcd')
   assert mocked_gfile_path.joinpath('bytes_file.txt').read_bytes() == b'abcd'
 
-  write_file_path = GcsPath('gs://text_file1.txt')
-  write_bytes_path = GcsPath('gs://bytes_file1.txt')
-
   # write_text() write_bytes()
-  write_file_path.write_text('abcd')
-  write_bytes_path.write_bytes(b'foobar')
+  GcsPath('gs://tfds_text.txt').write_text('tfds')
+  GcsPath('gs://tfds_byte.txt').write_bytes(b'tfds')
 
-  # read_text() read_bytes()
+  # read_text() and read_bytes()
+  assert GcsPath('gs://text_file.txt').read_text() == 'abcd'
+  assert GcsPath('gs://bytes_file.txt').read_bytes() == b'abcd'
+
+  assert GcsPath('gs://tfds_text.txt').read_text() == 'tfds'
+  assert GcsPath('gs://tfds_byte.txt').read_bytes() == b'tfds'
+
   assert mocked_gfile_path.joinpath('text_file1.txt').read_text() == 'abcd'
   assert mocked_gfile_path.joinpath('bytes_file1.txt').read_bytes() == b'foobar'
 
@@ -138,7 +141,7 @@ def test_rename_replace(mocked_gfile_path: pathlib.Path):
 
   assert mocked_gfile_path.joinpath('foo.py').exists()
 
-  # Rename()
+  # rename()
   src_path.rename('gs://bar.py')
 
   assert not mocked_gfile_path.joinpath('foo.py').exists()

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -30,6 +30,7 @@ def mocked_gfile_path(tmp_path: pathlib.Path):
   ):
     yield tmp_path
 
+
 def test_representations(mocked_gfile_path: pathlib.Path):
   g_path = GcsPath('gs://bucket/dir')
 
@@ -38,6 +39,16 @@ def test_representations(mocked_gfile_path: pathlib.Path):
   assert str(g_path) == 'gs://bucket/dir'
   assert os.fspath(g_path) == 'gs://bucket/dir'
 
+  g_path = GcsPath('/gs/bucket/datasets/')
+  assert str(g_path) == 'gs://bucket/datasets'
+  assert repr(g_path).startswith('GcsPath')
+
+  p = GcsPath(g_path, 'mnist', 'dataset.json')
+  assert str(p) == 'gs://bucket/datasets/mnist/dataset.json'
+
+  parts = [g_path, Path('mnist-100'), 'dataset.json']
+  assert '/'.join(os.fspath(p)
+                  for p in parts) == 'gs://bucket/datasets/mnist-100/dataset.json'
 
   with pytest.raises(ValueError, match='Invalid path'):
     GcsPath('/bucket/dir')

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -1,0 +1,23 @@
+"""Tests for tensorflow_datasets.core.utils.gpath."""
+
+import pytest
+import tensorflow as tf
+from tensorflow_datasets import testing
+from tensorflow_datasets.core.utils import gpath
+
+
+class GPathTest(testing.TestCase):
+
+
+  def test_path_exists(self):
+    PATH = "gs://tfds-data/datasets/mnist/3.0.0/"
+    g_path = gpath.GPath(PATH)
+    self.assertTrue(g_path.exists())
+
+  def test_path_not_exists(self):
+    PATH = "gs://tfds-data/foo/bar"
+    g_path = gpath.GPath(PATH)
+    self.assertFalse(g_path.exists())
+
+if __name__ == '__main__':
+  testing.test_main()

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -1,23 +1,112 @@
 """Tests for tensorflow_datasets.core.utils.gpath."""
 
+import os
+import pathlib
+
 import pytest
 import tensorflow as tf
+from pathlib import Path
 from tensorflow_datasets import testing
-from tensorflow_datasets.core.utils import gpath
+from tensorflow_datasets.core.utils.gpath import GcsPath
 
 
-class GPathTest(testing.TestCase):
+@pytest.fixture
+def mocked_gfile_path(tmp_path: pathlib.Path):
+  def _norm_path(path: str):
+    return path.replace('gs://', os.fspath(tmp_path) + '/')
+
+  with testing.mock_tf(
+      'tf.io.gfile',
+      exists=lambda p: os.path.exists(_norm_path(p)),
+      isdir=lambda p: os.path.isdir(_norm_path(p)),
+      listdir=lambda p: os.listdir(_norm_path(p)),
+      GFile=lambda p, *args, **kwargs: open(_norm_path(p), *args, **kwargs),
+      rename=lambda p1, p2: os.rename(_norm_path(p1), _norm_path(p2)),
+      replace=lambda p1, p2, **kwargs: os.replace(_norm_path(p1), _norm_path(p2), **kwargs),
+      mkdir=lambda p: os.mkdir(_norm_path(p)),
+      makedirs=lambda p: os.makedirs(_norm_path(p)),
+      glob=lambda p: Path(_norm_path(p)).parent.glob(Path(_norm_path(p)).stem)  # TODO: temporary func
+  ):
+    yield tmp_path
 
 
-  def test_path_exists(self):
-    PATH = "gs://tfds-data/datasets/mnist/3.0.0/"
-    g_path = gpath.GPath(PATH)
-    self.assertTrue(g_path.exists())
+def test_gfs(mocked_gfile_path: pathlib.Path):
+  g_path = GcsPath('gs://bucket/dir')
+  assert not g_path.exists()
 
-  def test_path_not_exists(self):
-    PATH = "gs://tfds-data/foo/bar"
-    g_path = gpath.GPath(PATH)
-    self.assertFalse(g_path.exists())
+  # mkdir()
+  g_path.mkdir(parents=True)
 
-if __name__ == '__main__':
-  testing.test_main()
+  # exists()
+  assert g_path.exists()
+  assert mocked_gfile_path.joinpath('bucket/dir').exists()
+
+  # is_dir()
+  assert not mocked_gfile_path.joinpath('read_text_file.txt').is_dir()
+  assert g_path.is_dir()
+
+
+def test_functions(mocked_gfile_path: pathlib.Path):
+
+  files = ['foo.py', 'bar.py', 'foo_bar.py', 'dataset.json',
+           'dataset_info.json', 'readme.md']
+  dataset_path = GcsPath('gs://bucket/dataset')
+
+  dataset_path.mkdir(parents=True)
+  assert dataset_path.exists()
+
+  # open()
+  for file in files:
+    with dataset_path.joinpath(file).open('w') as f:
+      f.write(' ')
+
+  # iterdir()
+  assert len(list(mocked_gfile_path.joinpath('bucket/dataset').iterdir())) == 6
+
+
+def test_read_write(mocked_gfile_path: pathlib.Path):
+  # read_text()
+  with tf.io.gfile.GFile('gs://text_file.txt', 'w') as f:
+    f.write('abcd')
+  assert mocked_gfile_path.joinpath('text_file.txt').read_text() == 'abcd'
+
+  # read_bytes()
+  with tf.io.gfile.GFile('gs://bytes_file.txt', 'wb') as f:
+    f.write(b'abcd')
+  assert mocked_gfile_path.joinpath('bytes_file.txt').read_bytes() == b'abcd'
+
+  write_file_path = GcsPath('gs://text_file1.txt')
+  write_bytes_path = GcsPath('gs://bytes_file1.txt')
+
+  # write_text() write_bytes()
+  write_file_path.write_text('abcd')
+  write_bytes_path.write_bytes(b'foobar')
+
+  # read_text() read_bytes()
+  assert mocked_gfile_path.joinpath('text_file1.txt').read_text() == 'abcd'
+  assert mocked_gfile_path.joinpath('bytes_file1.txt').read_bytes() == b'foobar'
+
+
+def test_mkdir(mocked_gfile_path: pathlib.Path):
+  g_path = GcsPath('gs://bucket')
+  assert not g_path.exists()
+
+  g_path.mkdir()
+  assert g_path.exists()
+  assert mocked_gfile_path.joinpath('bucket').exists()
+
+
+def test_rename_replace(mocked_gfile_path: pathlib.Path):
+  src_path = GcsPath('gs://foo.py')
+  src_path.write_text(' ')
+
+  assert mocked_gfile_path.joinpath('foo.py').exists()
+
+  # Rename()
+  # target_path = GcsPath('gs://foo.py')
+  src_path.rename('gs://bar.py')
+  # target = GcsPath(mocked_gfile_path.joinpath())
+  # GcsPath(mocked_gfile_path.joinpath('foo.py')).rename('bar.py')
+
+  assert not mocked_gfile_path.joinpath('foo.py').exists()
+  assert mocked_gfile_path.joinpath('bar.py').exists()

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -26,7 +26,7 @@ def mocked_gfile_path(tmp_path: pathlib.Path):
       replace=lambda p1, p2: os.replace(_norm_path(p1), _norm_path(p2)), # TODO: tf.io.gfile.rename() overwrite=True
       mkdir=lambda p: os.mkdir(_norm_path(p)),
       makedirs=lambda p: os.makedirs(_norm_path(p)),
-      glob=lambda p: Path(_norm_path(p)).parent.glob(Path(_norm_path(p)).stem)  # TODO: temporary func
+      glob=lambda p: Path(_norm_path(p)).parent.glob(Path(_norm_path(p)).stem)  # TODO: temporary function
   ):
     yield tmp_path
 
@@ -47,7 +47,7 @@ def test_gfs(mocked_gfile_path: pathlib.Path):
   assert g_path.is_dir()
 
 
-def test_functions(mocked_gfile_path: pathlib.Path):
+def test_open(mocked_gfile_path: pathlib.Path):
 
   files = ['foo.py', 'bar.py', 'foo_bar.py', 'dataset.json',
            'dataset_info.json', 'readme.md']
@@ -109,4 +109,4 @@ def test_rename_replace(mocked_gfile_path: pathlib.Path):
   assert not mocked_gfile_path.joinpath('foo.py').exists()
   assert mocked_gfile_path.joinpath('bar.py').exists()
 
-  # Replace() TODO:
+  # TODO: Replace()


### PR DESCRIPTION
##  Description

- Fixes #2568
- Added `GcsPath` class, a wrapper around `tf.io.gfile` with a `Pathlib` like interface.
- Added a tests

