### PR TITLE
Updated URLS for deep_weeds

### DIFF
--- a/tensorflow_datasets/image_classification/deep_weeds.py
+++ b/tensorflow_datasets/image_classification/deep_weeds.py
@@ -21,7 +21,7 @@ import os
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
-_URL = "https://docs.google.com/uc?export=download&id=1xnK3B6K6KekDI55vwJ0vnc2IGoDga9cj"
+_URL = "https://drive.google.com/uc?export=download&id=1xnK3B6K6KekDI55vwJ0vnc2IGoDga9cj"
 _URL_LABELS = "https://raw.githubusercontent.com/AlexOlsen/DeepWeeds/master/labels/labels.csv"
 
 _DESCRIPTION = (

--- a/tensorflow_datasets/image_classification/deep_weeds.py
+++ b/tensorflow_datasets/image_classification/deep_weeds.py
@@ -21,7 +21,7 @@ import os
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
-_URL = "https://nextcloud.qriscloud.org.au/index.php/s/a3KxPawpqkiorST/download"
+_URL = "https://docs.google.com/uc?export=download&id=1xnK3B6K6KekDI55vwJ0vnc2IGoDga9cj"
 _URL_LABELS = "https://raw.githubusercontent.com/AlexOlsen/DeepWeeds/master/labels/labels.csv"
 
 _DESCRIPTION = (

--- a/tensorflow_datasets/url_checksums/deep_weeds.txt
+++ b/tensorflow_datasets/url_checksums/deep_weeds.txt
@@ -1,2 +1,2 @@
-https://docs.google.com/uc?export=download&id=1xnK3B6K6KekDI55vwJ0vnc2IGoDga9cj 935276050 d616b33efe097909bdac9623abc5705b59ad11f6796a26a956c1aa5de652f1ba
-https://raw.githubusercontent.com/AlexOlsen/DeepWeeds/master/labels/labels.csv 598898 6fb95b89fd9d384f94e185a5cab6c5da7c987649399c90618ecc60acfb0112eb
+https://drive.google.com/uc?export=download&id=1xnK3B6K6KekDI55vwJ0vnc2IGoDga9cj	491516047	0961f63c01b997bfab1559ad09e99c0e8130617fd96a8b92fdc09940e01b0ce8	images.zip
+https://raw.githubusercontent.com/AlexOlsen/DeepWeeds/master/labels/labels.csv	598898	6fb95b89fd9d384f94e185a5cab6c5da7c987649399c90618ecc60acfb0112eb	labels.csv

--- a/tensorflow_datasets/url_checksums/deep_weeds.txt
+++ b/tensorflow_datasets/url_checksums/deep_weeds.txt
@@ -1,2 +1,2 @@
-https://nextcloud.qriscloud.org.au/index.php/s/a3KxPawpqkiorST/download 935276050 d616b33efe097909bdac9623abc5705b59ad11f6796a26a956c1aa5de652f1ba
+https://docs.google.com/uc?export=download&id=1xnK3B6K6KekDI55vwJ0vnc2IGoDga9cj 935276050 d616b33efe097909bdac9623abc5705b59ad11f6796a26a956c1aa5de652f1ba
 https://raw.githubusercontent.com/AlexOlsen/DeepWeeds/master/labels/labels.csv 598898 6fb95b89fd9d384f94e185a5cab6c5da7c987649399c90618ecc60acfb0112eb


### PR DESCRIPTION
Updated Image URL in deep_weeds.py and its corresponding url_checksum which was causing to break the dataset 

# Updated Dataset

* Dataset Name: deep_weeds
* Issue Reference: #2637 and tensorflow/tensorflow#44053
* `dataset_info.json` Gist: https://gist.github.com/PrattJena/f07615d011eb24474a75007bbc9bd4fc
  
## Description

<description>
  
## Checklist
* [x] Address all TODO's
* [x] Add alphabetized import to subdirectory's `__init__.py`
* [x] Run `download_and_prepare` successfully
* [x] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [x] Properly cite in `BibTeX` format
* [x] Add passing test(s)
* [x] Add test data
* [x] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [x] Add data generation script (if applicable)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
