### PR TITLE
gpath: add recursive support

### DIFF
--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -89,6 +89,16 @@ class _GPath(pathlib.PurePath, type_utils.ReadWritePath):
     """Returns the abolute path."""
     return self._new(posixpath.abspath(self._path_str))
 
+  def rglob(self: _P, pattern: str) -> Iterator[_P]:
+    """
+    Yielding all matching files (of any kind) recursively.
+    """
+    yield from self.glob(pattern)
+    if '**' in pattern:
+      for f in self.iterdir():
+        if f.is_dir():
+          yield from f.rglob(pattern)
+
   def glob(self: _P, pattern: str) -> Iterator[_P]:
     """Yielding all matching files (of any kind)."""
     for f in tf.io.gfile.glob(posixpath.join(self._path_str, pattern)):

--- a/tensorflow_datasets/core/utils/gpath_test.py
+++ b/tensorflow_datasets/core/utils/gpath_test.py
@@ -256,3 +256,28 @@ def test_replace(tmp_path: pathlib.Path):
   assert sorted(gpathlib.PosixGPath(tmp_path).iterdir()) == [
       tmp_path / 'mnist-100.py', tmp_path / 'tfds-dataset.py'
   ]
+
+@pytest.mark.parametrize(
+    'paths,patterns,results',
+    [
+      ('/tmp', 'a/**', [
+        gpathlib.PosixGPath('/tmp/a/b'),
+        gpathlib.PosixGPath('/tmp/a/b/c'),
+        gpathlib.PosixGPath('/tmp/a/b/c/d.txt')
+      ]),
+      ('/tmp/a', '**/*.txt', [
+        gpathlib.PosixGPath('/tmp/a/b/c/d.txt')
+      ]),
+      ('', '/tmp/a/**/*.txt', [
+        gpathlib.PosixGPath('/tmp/a/b/c/d.txt')
+      ]),
+    ],
+)
+def test_rglob(paths, patterns, results):
+  gpath = gpathlib.PosixGPath('/tmp/a/b/c')
+  if not gpath.exists():
+    gpath.mkdir(parents=True)
+    (gpath/'d.txt').touch()
+
+  gpath = gpathlib.PosixGPath(paths)
+  assert gpath.rglob(patterns) == results


### PR DESCRIPTION
Fix #2634
Note: This is currently supposed be used something like `Gpath('src').rglob('**/*.py')`. currently it will fail if there is any absolute path before `**` in the pattern.