### PR TITLE
[ENC] Better `tfds.as_dataframe` visualization

### DIFF
--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -101,6 +101,7 @@ class BBoxFeature(feature.Tensor):
 
   def repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of an Image with BBoxes."""
+    ex = np.expand_dims(ex, axis=0)  # Convert single bounding box to single batch.
     return self._repr_html(ex)
 
   def repr_html_batch(self, ex: np.ndarray) -> str:

--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -83,7 +83,7 @@ class BBoxFeature(feature.Tensor):
     )
 
   def _build_thumbnail_with_bbox(self, ex: np.ndarray) -> str:
-    """Returns the HTML str representation of an Image with BBoxes."""
+    """Returns blank image with Bboxes drawn on it."""
     PIL_Image = lazy_imports_lib.lazy_imports.PIL_Image
     PIL_ImageDraw = lazy_imports_lib.lazy_imports.PIL_ImageDraw
 
@@ -100,11 +100,9 @@ class BBoxFeature(feature.Tensor):
     return blank_img
 
   def repr_html_batch(self, ex: np.ndarray) -> str:
-    """Returns the HTML str representation of the object."""
+    """Returns the HTML str representation of an Image with BBoxes."""
     img = self._build_thumbnail_with_bbox(ex)
-
     img_str = utils.get_base64(lambda buff: img.save(buff, format='PNG'))
-
     return f'<img src="data:image/png;base64,{img_str}" alt="Img" />'
 
   @classmethod

--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -90,12 +90,13 @@ class BBoxFeature(feature.Tensor):
     SIZE = 150
     blank_img = PIL_Image.new('RGB', (SIZE, SIZE), (255, 255, 255))
     draw = PIL_ImageDraw.Draw(blank_img)
+    rs = np.random.RandomState(97531)  # freeze random state
 
     for i in range(ex.shape[0]):
       # Rescale coordinates to match size of blank_image
       ymin, xmin, ymax, xmax = ex[i, :]*SIZE
       # Generate random rgb values for Bbox ouline
-      r, g, b = list(np.random.randint(0, 256, size=3))
+      r, g, b = list(rs.randint(0, 256, size=3))
       draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))
     return blank_img
 

--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -85,17 +85,11 @@ class BBoxFeature(feature.Tensor):
   def repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of an Image with BBoxes."""
     ex = np.expand_dims(ex, axis=0)  # Convert single bounding box to single batch.
-    return self._repr_html(ex)
+    return _repr_html(ex)
 
   def repr_html_batch(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of an Image with BBoxes (Sequence)."""
-    return self._repr_html(ex)
-
-  def _repr_html(self, ex: np.ndarray) -> str:
-    """Returns the HTML str representation of an Image with BBoxes."""
-    img = _build_thumbnail_with_bbox(ex)
-    img_str = utils.get_base64(lambda buff: img.save(buff, format='PNG'))
-    return f'<img src="data:image/png;base64,{img_str}" alt="Img" />'
+    return _repr_html(ex)
 
   @classmethod
   def from_json_content(cls, value: Json) -> 'BBoxFeature':
@@ -104,6 +98,12 @@ class BBoxFeature(feature.Tensor):
 
   def to_json_content(self) -> Json:
     return dict()
+
+def _repr_html(ex: np.ndarray) -> str:
+  """Returns the HTML str representation of an Image with BBoxes."""
+  img = _build_thumbnail_with_bbox(ex)
+  img_str = utils.get_base64(lambda buff: img.save(buff, format='PNG'))
+  return f'<img src="data:image/png;base64,{img_str}" alt="Img" />'
 
 def _build_thumbnail_with_bbox(ex: np.ndarray):
   """Returns blank image with Bboxes drawn on it."""

--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -82,7 +82,7 @@ class BBoxFeature(feature.Tensor):
         [bbox.ymin, bbox.xmin, bbox.ymax, bbox.xmax]
     )
 
-  def _build_thumbnail_with_bbox(self, ex: np.ndarray) -> str:
+  def _build_thumbnail_with_bbox(self, ex: np.ndarray):
     """Returns blank image with Bboxes drawn on it."""
     PIL_Image = lazy_imports_lib.lazy_imports.PIL_Image
     PIL_ImageDraw = lazy_imports_lib.lazy_imports.PIL_ImageDraw

--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -82,24 +82,6 @@ class BBoxFeature(feature.Tensor):
         [bbox.ymin, bbox.xmin, bbox.ymax, bbox.xmax]
     )
 
-  def _build_thumbnail_with_bbox(self, ex: np.ndarray):
-    """Returns blank image with Bboxes drawn on it."""
-    PIL_Image = lazy_imports_lib.lazy_imports.PIL_Image
-    PIL_ImageDraw = lazy_imports_lib.lazy_imports.PIL_ImageDraw
-
-    SIZE = 150
-    blank_img = PIL_Image.new('RGB', (SIZE, SIZE), (255, 255, 255))
-    draw = PIL_ImageDraw.Draw(blank_img)
-    rs = np.random.RandomState(97531)  # freeze random state
-
-    for i in range(ex.shape[0]):
-      # Rescale coordinates to match size of blank_image
-      ymin, xmin, ymax, xmax = ex[i, :]*SIZE
-      # Generate random rgb values for Bbox ouline
-      r, g, b = list(rs.randint(0, 256, size=3))
-      draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))
-    return blank_img
-
   def repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of an Image with BBoxes."""
     ex = np.expand_dims(ex, axis=0)  # Convert single bounding box to single batch.
@@ -111,7 +93,7 @@ class BBoxFeature(feature.Tensor):
 
   def _repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of an Image with BBoxes."""
-    img = self._build_thumbnail_with_bbox(ex)
+    img = _build_thumbnail_with_bbox(ex)
     img_str = utils.get_base64(lambda buff: img.save(buff, format='PNG'))
     return f'<img src="data:image/png;base64,{img_str}" alt="Img" />'
 
@@ -122,3 +104,21 @@ class BBoxFeature(feature.Tensor):
 
   def to_json_content(self) -> Json:
     return dict()
+
+def _build_thumbnail_with_bbox(ex: np.ndarray):
+  """Returns blank image with Bboxes drawn on it."""
+  PIL_Image = lazy_imports_lib.lazy_imports.PIL_Image
+  PIL_ImageDraw = lazy_imports_lib.lazy_imports.PIL_ImageDraw
+
+  SIZE = 150
+  blank_img = PIL_Image.new('RGB', (SIZE, SIZE), (255, 255, 255))
+  draw = PIL_ImageDraw.Draw(blank_img)
+  rs = np.random.RandomState(97531)  # freeze random state
+
+  for i in range(ex.shape[0]):
+    # Rescale coordinates to match size of blank_image
+    ymin, xmin, ymax, xmax = ex[i, :]*SIZE
+    # Generate random rgb values for Bbox ouline
+    r, g, b = list(rs.randint(0, 256, size=3))
+    draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))
+  return blank_img

--- a/tensorflow_datasets/core/features/bounding_boxes.py
+++ b/tensorflow_datasets/core/features/bounding_boxes.py
@@ -99,7 +99,15 @@ class BBoxFeature(feature.Tensor):
       draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))
     return blank_img
 
+  def repr_html(self, ex: np.ndarray) -> str:
+    """Returns the HTML str representation of an Image with BBoxes."""
+    return self._repr_html(ex)
+
   def repr_html_batch(self, ex: np.ndarray) -> str:
+    """Returns the HTML str representation of an Image with BBoxes (Sequence)."""
+    return self._repr_html(ex)
+
+  def _repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of an Image with BBoxes."""
     img = self._build_thumbnail_with_bbox(ex)
     img_str = utils.get_base64(lambda buff: img.save(buff, format='PNG'))

--- a/tensorflow_datasets/core/features/feature.py
+++ b/tensorflow_datasets/core/features/feature.py
@@ -26,7 +26,6 @@ import six
 import tensorflow.compat.v2 as tf
 
 from tensorflow_datasets.core import utils
-from tensorflow_datasets.core import lazy_imports_lib
 from tensorflow_datasets.core.utils import type_utils
 
 Json = type_utils.Json
@@ -445,34 +444,12 @@ class FeatureConnector(object):
     """
     return tf.ragged.map_flat_values(self.decode_batch_example, tfexample_data)
 
-  def _build_thumbnail_with_bbox(self, ex: np.ndarray) -> str:
-    """Returns the HTML str representation of an Image with BBoxes."""
-    PIL_Image = lazy_imports_lib.lazy_imports.PIL_Image
-    PIL_ImageDraw = lazy_imports_lib.lazy_imports.PIL_ImageDraw
-
-    SIZE = 150
-    blank_img = PIL_Image.new('RGB', (SIZE, SIZE), (255, 255, 255))
-    draw = PIL_ImageDraw.Draw(blank_img)
-
-    for i in range(ex.shape[0]):
-      # Rescale coordinates to match size of blank_image
-      ymin, xmin, ymax, xmax = ex[i, :]*SIZE
-      # Generate random rgb values for Bbox ouline
-      r, g, b = list(np.random.randint(0, 256, size=3))
-      draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))
-
-    img_str = utils.get_base64(lambda buff: blank_img.save(buff, format='PNG'))
-
-    return f'<img src="data:image/png;base64,{img_str}" alt="Img" />'
-
   def repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of the object."""
     return _repr_html(ex)
 
   def repr_html_batch(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of the object (Sequence)."""
-    if len(ex.shape) > 1 and ex.shape[1] == 4:
-      return self._build_thumbnail_with_bbox(ex)
     return _repr_html(ex)
 
   def repr_html_ragged(self, ex: np.ndarray) -> str:

--- a/tensorflow_datasets/core/features/feature.py
+++ b/tensorflow_datasets/core/features/feature.py
@@ -456,7 +456,7 @@ class FeatureConnector(object):
 
     for i in range(ex.shape[0]):
       # Rescale coordinates to match size of blank_image
-      ymin, xmin, ymax, xmax = ex[i, :]*150
+      ymin, xmin, ymax, xmax = ex[i, :]*SIZE
       # Generate random rgb values for Bbox ouline
       r, g, b = list(np.random.randint(0, 256, size=3))
       draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))

--- a/tensorflow_datasets/core/features/feature.py
+++ b/tensorflow_datasets/core/features/feature.py
@@ -26,6 +26,7 @@ import six
 import tensorflow.compat.v2 as tf
 
 from tensorflow_datasets.core import utils
+from tensorflow_datasets.core import lazy_imports_lib
 from tensorflow_datasets.core.utils import type_utils
 
 Json = type_utils.Json
@@ -444,12 +445,34 @@ class FeatureConnector(object):
     """
     return tf.ragged.map_flat_values(self.decode_batch_example, tfexample_data)
 
+  def _build_thumbnail_with_bbox(self, ex: np.ndarray) -> str:
+    """Returns the HTML str representation of an Image with BBoxes."""
+    PIL_Image = lazy_imports_lib.lazy_imports.PIL_Image
+    PIL_ImageDraw = lazy_imports_lib.lazy_imports.PIL_ImageDraw
+
+    SIZE = 150
+    blank_img = PIL_Image.new('RGB', (SIZE, SIZE), (255, 255, 255))
+    draw = PIL_ImageDraw.Draw(blank_img)
+
+    for i in range(ex.shape[0]):
+      # Rescale coordinates to match size of blank_image
+      ymin, xmin, ymax, xmax = ex[i, :]*150
+      # Generate random rgb values for Bbox ouline
+      r, g, b = list(np.random.randint(0, 256, size=3))
+      draw.rectangle(((xmin, ymin), (xmax, ymax)), outline=(r, g, b))
+
+    img_str = utils.get_base64(lambda buff: blank_img.save(buff, format='PNG'))
+
+    return f'<img src="data:image/png;base64,{img_str}" alt="Img" />'
+
   def repr_html(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of the object."""
     return _repr_html(ex)
 
   def repr_html_batch(self, ex: np.ndarray) -> str:
     """Returns the HTML str representation of the object (Sequence)."""
+    if len(ex.shape) > 1 and ex.shape[1] == 4:
+      return self._build_thumbnail_with_bbox(ex)
     return _repr_html(ex)
 
   def repr_html_ragged(self, ex: np.ndarray) -> str:

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -115,7 +115,7 @@ class Video(sequence_feature.Sequence):
 
   @property
   def _ffmpeg_path(self):
-    return '/Users/harsh/Desktop/ffmpeg_dependencies/ffmpeg/ffmpeg'
+    return 'ffmpeg'
 
   def _ffmpeg_run(self, ffmpeg_args, ffmpeg_stdin=None):
     process = subprocess.Popen(ffmpeg_args,

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -201,7 +201,7 @@ class Video(sequence_feature.Sequence):
         '-vf', 'scale=128:128', # scale output videos to 128x128
         # using native h264 encoder
         '-vcodec', 'h264',      # output video stream codec - H.264
-        '-pix_fmt', 'yuv420p',  # use yuv420v pixel format (ensure wide compatibility)
+        '-pix_fmt', 'yuv420p',  # use yuv420v pixel format (enhance compatibility)
         '-allow_sw', '1'        # allow software encoding
       ]
       ffmpeg_stdin = None
@@ -226,7 +226,6 @@ class Video(sequence_feature.Sequence):
 
       except OSError:
         # if ffmpeg is not installed, generate GIF using pngs
-        duration = (41*24)/framerate
         def write_buff(buff):
           images[0].save(
               buff,
@@ -234,7 +233,7 @@ class Video(sequence_feature.Sequence):
               save_all=True,
               append_images=images[1:],
               # Could add a frame_rate kwargs in __init__ to customize this.
-              duration=duration,  # 41ms / img ~= 24 img / sec
+              duration=1000/framerate,  # 41ms / img ~= 24 img / sec
               loop=0,
           )
 

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -217,6 +217,7 @@ class Video(sequence_feature.Sequence):
           '-vcodec', 'h264',      # output video stream codec - H.264
           # When outputting H.264 ensures compatibility so crappy
           # players can decode the video
+          # Ref: https://trac.ffmpeg.org/wiki/Slideshow
           '-pix_fmt', 'yuv420p',  # use yuv420v pixel format
           # native encoder cannot encode images of small scale
           # or the the hardware encoder may be busy which raises

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -197,10 +197,10 @@ class Video(sequence_feature.Sequence):
         'ffmpeg_extra_args': self._extra_ffmpeg_args
     }
 
-  def _generate_video(self, images, framerate=24, encoding_format='mp4') -> str:
+  def _generate_video_html(self, images, framerate=24, encoding_format='mp4') -> str:
     """Converts sequence of images into video string."""
     # CODE REDUNDANT: Could somehow use `_ffmpeg_decode`?
-    imgs = len(str(len(images)))+1  # Find number of digits required to give names.
+    imgs = len(str(len(images)))+1  # Find number of digits in len to give names.
     video_dir = tempfile.mkdtemp()
     for i, img in enumerate(images):
       f = os.path.join(video_dir, f'img{i:0{imgs}d}.png')
@@ -236,7 +236,9 @@ class Video(sequence_feature.Sequence):
       def write_buff(buff):
         buff.write(video)
       video_str = utils.get_base64(write_buff)
-      return video_str
+      return (f'<video height="128" width="128" controls loop>'
+              f'<source src="data:image/gif;base64,{video_str}"'
+              f' type="video/mp4" alt="Video"></video>')
 
     except OSError:
       # if ffmpeg is not installed, generate GIF using pngs
@@ -254,7 +256,7 @@ class Video(sequence_feature.Sequence):
 
       # Convert to base64
       gif_str = utils.get_base64(write_buff)
-      return gif_str
+      return f'<img src="data:image/png;base64,{gif_str}" alt="Gif" />'
 
     finally:
       tf.io.gfile.rmtree(video_dir)
@@ -264,9 +266,7 @@ class Video(sequence_feature.Sequence):
     # Use GIF to generate a HTML5 compatible video if FFMPEG is not
     # installed on the system.
     images = [image_feature.create_thumbnail(frame) for frame in ex]
-    video_str = self._generate_video(images, framerate=10)
+    video_html = self._generate_video_html(images, framerate=10)
 
     # Display HTML
-    return (f'<video height="128" width="128" controls loop>'
-            f'<source src="data:image/gif;base64,{video_str}"'
-            f' type="video/mp4" alt="Video"></video>')
+    return video_html

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -200,7 +200,7 @@ class Video(sequence_feature.Sequence):
   def _generate_video(self, images, framerate=24, encoding_format='mp4') -> str:
     """Converts sequence of images into video string."""
     # CODE REDUNDANT: Could somehow use `_ffmpeg_decode`?
-    imgs = len(images)-1
+    imgs = len(str(len(images)))+1  # Find number of digits required to give names.
     video_dir = tempfile.mkdtemp()
     for i, img in enumerate(images):
       f = os.path.join(video_dir, f'img{i:0{imgs}d}.png')

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -117,22 +117,6 @@ class Video(sequence_feature.Sequence):
   def _ffmpeg_path(self):
     return 'ffmpeg'
 
-  def _ffmpeg_run(self, ffmpeg_args, ffmpeg_stdin=None):
-    process = subprocess.Popen(ffmpeg_args,
-                                 stdin=subprocess.PIPE,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
-
-    stdout_data, stderr_data = process.communicate(ffmpeg_stdin)
-    ffmpeg_ret_code = process.returncode
-    if ffmpeg_ret_code:
-      raise ValueError(
-          'ffmpeg returned error code {}, command={}\n'
-          'stdout={}\nstderr={}\n'.format(ffmpeg_ret_code,
-                                          ' '.join(ffmpeg_args),
-                                          stdout_data,
-                                          stderr_data))
-
   def _ffmpeg_decode(self, path_or_fobj):
     if isinstance(path_or_fobj, type_utils.PathLikeCls):
       ffmpeg_args = [self._ffmpeg_path, '-i', os.fspath(path_or_fobj)]
@@ -146,7 +130,7 @@ class Video(sequence_feature.Sequence):
     ffmpeg_args += self._extra_ffmpeg_args
     ffmpeg_args.append(output_pattern)
     try:
-      self._ffmped_run(ffmpeg_args, ffmpeg_stdin)
+      _ffmpeg_run(ffmpeg_args, ffmpeg_stdin)
       frames = []
       for image_name in sorted(tf.io.gfile.listdir(ffmpeg_dir)):
         image_path = os.path.join(ffmpeg_dir, image_name)
@@ -221,7 +205,7 @@ class Video(sequence_feature.Sequence):
       ffmpeg_args += extra_ffmpeg_args
       ffmpeg_args.append(output_pattern)
       try:
-        self._ffmpeg_run(ffmpeg_args, ffmpeg_stdin)
+        _ffmpeg_run(ffmpeg_args, ffmpeg_stdin)
 
         video = None
         video_file = os.path.join(video_dir, 'output.mp4')
@@ -262,3 +246,19 @@ class Video(sequence_feature.Sequence):
 
     # Display HTML
     return video_html
+
+def _ffmpeg_run(ffmpeg_args, ffmpeg_stdin=None):
+  process = subprocess.Popen(ffmpeg_args,
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+  stdout_data, stderr_data = process.communicate(ffmpeg_stdin)
+  ffmpeg_ret_code = process.returncode
+  if ffmpeg_ret_code:
+    raise ValueError(
+        'ffmpeg returned error code {}, command={}\n'
+        'stdout={}\nstderr={}\n'.format(ffmpeg_ret_code,
+                                        ' '.join(ffmpeg_args),
+                                        stdout_data,
+                                        stderr_data))

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -115,7 +115,7 @@ class Video(sequence_feature.Sequence):
 
   @property
   def _ffmpeg_path(self):
-    return 'ffmpeg'
+    return '/Users/harsh/Desktop/ffmpeg_dependencies/ffmpeg/ffmpeg'
 
   def _ffmpeg_decode(self, path_or_fobj):
     if isinstance(path_or_fobj, type_utils.PathLikeCls):
@@ -197,8 +197,13 @@ class Video(sequence_feature.Sequence):
       ffmpeg_args = [self._ffmpeg_path, '-framerate', str(framerate), '-i',
                     os.fspath(os.path.join(video_dir, f'img%0{imgs}d.png'))]
 
-      extra_ffmpeg_args = ['-vf', 'scale=128:128', '-vcodec', 'h264',
-                           '-pix_fmt', 'yuv420p', '-allow_sw', '1']
+      extra_ffmpeg_args = [
+        '-vf', 'scale=128:128', # scale output videos to 128x128
+        # using native h264 encoder
+        '-vcodec', 'h264',      # output video stream codec - H.264
+        '-pix_fmt', 'yuv420p',  # use yuv420v pixel format (ensure wide compatibility)
+        '-allow_sw', '1'        # allow software encoding
+      ]
       ffmpeg_stdin = None
 
       output_pattern = os.path.join(video_dir, 'output.' + encoding_format)
@@ -216,7 +221,7 @@ class Video(sequence_feature.Sequence):
           buff.write(video)
         video_str = utils.get_base64(write_buff)
         return (f'<video height="128" width="128" controls loop plays-inline>'
-                f'<source src="data:image/gif;base64,{video_str}"'
+                f'<source src="data:image/video;base64,{video_str}"'
                 f' type="video/mp4" alt="Video"></video>')
 
       except OSError:

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -185,17 +185,17 @@ class Video(sequence_feature.Sequence):
         'ffmpeg_extra_args': self._extra_ffmpeg_args
     }
 
-  def _generate_video_html(self, images, framerate=24, encoding_format='mp4') -> str:
+  def _generate_video_html(self, images, framerate=24) -> str:
     """Converts sequence of images into video string."""
-    imgs = len(str(len(images)))+1  # Find number of digits in len to give names.
+    num_digits = len(str(len(images)))+1  # Find number of digits in len to give names.
 
     with tempfile.TemporaryDirectory() as video_dir:
       for i, img in enumerate(images):
-        f = os.path.join(video_dir, f'img{i:0{imgs}d}.png')
+        f = os.path.join(video_dir, f'img{i:0{num_digits}d}.png')
         img.save(f, format='png')
 
       ffmpeg_args = [self._ffmpeg_path, '-framerate', str(framerate), '-i',
-                    os.fspath(os.path.join(video_dir, f'img%0{imgs}d.png'))]
+                    os.fspath(os.path.join(video_dir, f'img%0{num_digits}d.png'))]
 
       extra_ffmpeg_args = [
         '-vf', 'scale=128:128', # scale output videos to 128x128
@@ -206,7 +206,7 @@ class Video(sequence_feature.Sequence):
       ]
       ffmpeg_stdin = None
 
-      output_pattern = os.path.join(video_dir, 'output.' + encoding_format)
+      output_pattern = os.path.join(video_dir, 'output.mp4')
       ffmpeg_args += extra_ffmpeg_args
       ffmpeg_args.append(output_pattern)
       try:

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -225,7 +225,6 @@ class Video(sequence_feature.Sequence):
 
         _ffmpeg_run(ffmpeg_args)
 
-        video = None
         video_file = os.path.join(video_dir, 'output.mp4')
         with tf.io.gfile.GFile(video_file, 'rb') as vf:
           video = vf.read()

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -115,7 +115,7 @@ class Video(sequence_feature.Sequence):
 
   @property
   def _ffmpeg_path(self):
-    return '/Users/harsh/Desktop/ffmpeg_dependencies/ffmpeg/ffmpeg'
+    return 'ffmpeg'
 
   def _ffmpeg_decode(self, path_or_fobj):
     if isinstance(path_or_fobj, type_utils.PathLikeCls):

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -115,7 +115,7 @@ class Video(sequence_feature.Sequence):
 
   @property
   def _ffmpeg_path(self):
-    return 'ffmpeg'
+    return '/Users/harsh/Desktop/ffmpeg_dependencies/ffmpeg/ffmpeg'
 
   def _ffmpeg_run(self, ffmpeg_args, ffmpeg_stdin=None):
     process = subprocess.Popen(ffmpeg_args,
@@ -211,13 +211,14 @@ class Video(sequence_feature.Sequence):
         img.save(f, format='png')
 
       ffmpeg_args = [self._ffmpeg_path, '-framerate', str(framerate), '-i',
-                    os.fspath(os.path.join(video_dir, f'img%0{imgs}d.png')),
-                    '-vf', 'scale=128:128', '-vcodec', 'h264',
-                    '-pix_fmt', 'yuv420p', '-allow_sw', '1']
+                    os.fspath(os.path.join(video_dir, f'img%0{imgs}d.png'))]
+
+      extra_ffmpeg_args = ['-vf', 'scale=128:128', '-vcodec', 'h264',
+                           '-pix_fmt', 'yuv420p', '-allow_sw', '1']
       ffmpeg_stdin = None
 
       output_pattern = os.path.join(video_dir, 'output.' + encoding_format)
-      ffmpeg_args += self._extra_ffmpeg_args
+      ffmpeg_args += extra_ffmpeg_args
       ffmpeg_args.append(output_pattern)
       try:
         self._ffmpeg_run(ffmpeg_args, ffmpeg_stdin)

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -236,7 +236,7 @@ class Video(sequence_feature.Sequence):
       def write_buff(buff):
         buff.write(video)
       video_str = utils.get_base64(write_buff)
-      return (f'<video height="128" width="128" controls loop>'
+      return (f'<video height="128" width="128" controls loop plays-inline>'
               f'<source src="data:image/gif;base64,{video_str}"'
               f' type="video/mp4" alt="Video"></video>')
 

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -208,7 +208,9 @@ class Video(sequence_feature.Sequence):
         img.save(f, format='png')
 
       ffmpeg_args = [self._ffmpeg_path, '-framerate', str(framerate), '-i',
-                    os.fspath(os.path.join(video_dir, f'img%0{imgs}d.png'))]
+                    os.fspath(os.path.join(video_dir, f'img%0{imgs}d.png')),
+                    '-vf', 'scale=128:128', '-vcodec', 'h264',
+                    '-pix_fmt', 'yuv420p', '-allow_sw', '1']
       ffmpeg_stdin = None
 
       output_pattern = os.path.join(video_dir, 'output.' + encoding_format)

--- a/tensorflow_datasets/core/features/video_feature.py
+++ b/tensorflow_datasets/core/features/video_feature.py
@@ -212,10 +212,16 @@ class Video(sequence_feature.Sequence):
                       os.fspath(os.path.join(video_dir, f'img%0{num_digits}d.png'))]
 
         extra_ffmpeg_args = [
-          '-vf', 'scale=128:128', # scale output videos to 128x128
-          # using native h264 encoder
+          # using native h264 to encode video stream to H.264 codec
+          # it enables chrome support
           '-vcodec', 'h264',      # output video stream codec - H.264
-          '-pix_fmt', 'yuv420p',  # use yuv420v pixel format (enhance compatibility)
+          # When outputting H.264 ensures compatibility so crappy
+          # players can decode the video
+          '-pix_fmt', 'yuv420p',  # use yuv420v pixel format
+          # native encoder cannot encode images of small scale
+          # or the the hardware encoder may be busy which raises
+          # Error: cannot create compression session
+          # so allow software encoding
           '-allow_sw', '1'        # allow software encoding
         ]
 
@@ -233,7 +239,7 @@ class Video(sequence_feature.Sequence):
           buff.write(video)
         video_str = utils.get_base64(write_buff)
         return (f'<video height="128" width="128" controls loop plays-inline>'
-                f'<source src="data:image/video;base64,{video_str}"'
+                f'<source src="data:video/mp4;base64,{video_str}"'
                 f' type="video/mp4" alt="Video"></video>')
 
   def repr_html(self, ex: np.ndarray) -> str:

--- a/tensorflow_datasets/core/lazy_imports_lib.py
+++ b/tensorflow_datasets/core/lazy_imports_lib.py
@@ -117,6 +117,14 @@ class LazyImporter(object):
 
   @utils.classproperty
   @classmethod
+  def PIL_ImageDraw(cls):  # pylint: disable=invalid-name
+    # TiffImagePlugin need to be activated explicitly on some systems
+    # https://github.com/python-pillow/Pillow/blob/5.4.x/src/PIL/Image.py#L407
+    _try_import("PIL.TiffImagePlugin")
+    return _try_import("PIL.ImageDraw")
+
+  @utils.classproperty
+  @classmethod
   def pretty_midi(cls):
     return _try_import("pretty_midi")
 


### PR DESCRIPTION
### Better `tfds.as_dataframe` visualization

Fixes issue #2791 

Tasks:
* [x] `BBoxFeature` inside `Sequence`: Display some boxes in some empty 150x150px image
* [ ] `ClassLabel/Tensor` inside `Sequence`: Maybe display a dropdown list with individual values
* [x] Video could also be greatly improved. If ffmpeg is found, it would be nice to generate a proper `.mp4` video which would be more compressed than .gif and would have play/pause controls.
* [x] The video framerate should also be greatly reduced. Currently, video like https://www.tensorflow.org/datasets/catalog/abstract_reasoning are much too fast