### PR TITLE
Add multichannel audio support to tfds.features.Audio.

### DIFF
--- a/tensorflow_datasets/core/features/audio_feature.py
+++ b/tensorflow_datasets/core/features/audio_feature.py
@@ -131,9 +131,9 @@ def _save_wav(buff, data, rate) -> None:
   num_channels = data.shape[1] if len(data.shape) > 1 else 1
   scaled = np.int16(data / np.max(np.abs(data)) * 32767)
 
-  with wave.open(buff, mode="wb") as waveobj:
+  with wave.open(buff, mode='wb') as waveobj:
     waveobj.setnchannels(num_channels)
     waveobj.setframerate(rate)
     waveobj.setsampwidth(2)
-    waveobj.setcomptype("NONE", "NONE")
-    waveobj.writeframes(scaled.astype("<i2", copy=False).tostring())
+    waveobj.setcomptype('NONE', 'NONE')
+    waveobj.writeframes(scaled.astype('<i2', copy=False).tostring())

--- a/tensorflow_datasets/core/features/audio_feature.py
+++ b/tensorflow_datasets/core/features/audio_feature.py
@@ -16,7 +16,6 @@
 """Audio feature."""
 
 import os
-import struct
 import wave
 
 import numpy as np

--- a/tensorflow_datasets/core/features/audio_feature.py
+++ b/tensorflow_datasets/core/features/audio_feature.py
@@ -132,8 +132,8 @@ def _save_wav(buff, data, rate) -> None:
   scaled = np.int16(data / np.max(np.abs(data)) * 32767)
 
   with wave.open(buff, mode="wb") as waveobj:
-      waveobj.setnchannels(num_channels)
-      waveobj.setframerate(rate)
-      waveobj.setsampwidth(2)
-      waveobj.setcomptype("NONE", "NONE")
-      waveobj.writeframes(scaled.astype("<i2", copy=False).tostring())
+    waveobj.setnchannels(num_channels)
+    waveobj.setframerate(rate)
+    waveobj.setsampwidth(2)
+    waveobj.setcomptype("NONE", "NONE")
+    waveobj.writeframes(scaled.astype("<i2", copy=False).tostring())

--- a/tensorflow_datasets/core/features/audio_feature_test.py
+++ b/tensorflow_datasets/core/features/audio_feature_test.py
@@ -30,103 +30,125 @@ tf.enable_v2_behavior()
 
 class AudioFeatureTest(testing.FeatureExpectationsTestCase):
 
-  def create_np_audio(self):
-    return np.random.randint(-2**10, 2**10, size=(10,), dtype=np.int64)
+  def shape_for_channels(self, num_channels, length=None):
+    if num_channels == 1:
+      return (length,)
+    else:
+      return (length, num_channels)
+
+  def create_np_audio(self, num_channels=1):
+    return np.random.randint(
+        -2**10,
+        2**10,
+        size=self.shape_for_channels(num_channels, 10),
+        dtype=np.int64
+    )
 
   def test_numpy_array(self):
-    np_audio = self.create_np_audio()
+    for num_channels in (1, 2, 8):
+      np_audio = self.create_np_audio(num_channels)
 
-    self.assertFeature(
-        feature=features.Audio(sample_rate=1000),
-        shape=(None,),
-        dtype=tf.int64,
-        tests=[
-            testing.FeatureExpectationItem(
-                value=np_audio,
-                expected=np_audio,
-            ),
-        ],
-        test_attributes=dict(
-            _file_format=None,
-            sample_rate=1000,
-        )
-    )
-
-  def test_numpy_array_float(self):
-    np_audio = self.create_np_audio().astype(np.float32)
-    self.assertFeature(
-        feature=features.Audio(dtype=tf.float32),
-        shape=(None,),
-        dtype=tf.float32,
-        tests=[
-            testing.FeatureExpectationItem(
-                value=np_audio,
-                expected=np_audio,
-            ),
-        ],
-    )
-
-  def write_wave_file(self, np_audio, path):
-    audio = pydub.AudioSegment.empty().set_sample_width(2)
-    # See documentation for _spawn usage:
-    # https://github.com/jiaaro/pydub/blob/master/API.markdown#audiosegmentget_array_of_samples
-    audio = audio._spawn(array.array(audio.array_type, np_audio))
-    audio.export(path, format="wav")
-
-  def test_wav_file(self):
-
-    np_audio = self.create_np_audio()
-    _, tmp_file = tempfile.mkstemp()
-    self.write_wave_file(np_audio, tmp_file)
-
-    self.assertFeature(
-        feature=features.Audio(file_format="wav"),
-        shape=(None,),
-        dtype=tf.int64,
-        tests=[
-            testing.FeatureExpectationItem(
-                value=tmp_file,
-                expected=np_audio,
-            ),
-            testing.FeatureExpectationItem(
-                value=pathlib.Path(tmp_file),
-                expected=np_audio,
-            ),
-        ],
-        test_attributes=dict(
-            _file_format="wav",
-        )
-    )
-
-  def test_file_object(self):
-    np_audio = self.create_np_audio()
-    _, tmp_file = tempfile.mkstemp()
-    self.write_wave_file(np_audio, tmp_file)
-
-    class GFileWithSeekOnRead(tf.io.gfile.GFile):
-      """Wrapper around GFile which is reusable across multiple read() calls.
-
-      This is needed because assertFeature reuses the same
-      FeatureExpectationItem several times.
-      """
-
-      def read(self, *args, **kwargs):
-        data_read = super(GFileWithSeekOnRead, self).read(*args, **kwargs)
-        self.seek(0)
-        return data_read
-
-    with GFileWithSeekOnRead(tmp_file, "rb") as file_obj:
       self.assertFeature(
-          feature=features.Audio(file_format="wav"),
-          shape=(None,),
+          feature=features.Audio(
+              sample_rate=1000, shape=self.shape_for_channels(num_channels)
+          ),
+          shape=self.shape_for_channels(num_channels),
           dtype=tf.int64,
           tests=[
               testing.FeatureExpectationItem(
-                  value=file_obj,
+                  value=np_audio,
+                  expected=np_audio,
+              ),
+          ],
+          test_attributes=dict(
+              _file_format=None,
+              sample_rate=1000,
+          )
+      )
+
+  def test_numpy_array_float(self):
+    for num_channels in (1, 2, 8):
+      np_audio = self.create_np_audio(num_channels).astype(np.float32)
+      self.assertFeature(
+          feature=features.Audio(
+              dtype=tf.float32, shape=self.shape_for_channels(num_channels)
+          ),
+          shape=self.shape_for_channels(num_channels),
+          dtype=tf.float32,
+          tests=[
+              testing.FeatureExpectationItem(
+                  value=np_audio,
                   expected=np_audio,
               ),
           ],
       )
+
+  def write_wave_file(self, np_audio, path):
+    num_channels = np_audio.shape[1] if len(np_audio.shape) == 2 else 1
+    audio = pydub.AudioSegment.empty(
+    ).set_sample_width(2).set_channels(num_channels)
+    # See documentation for _spawn usage:
+    # https://github.com/jiaaro/pydub/blob/master/API.markdown#audiosegmentget_array_of_samples
+    audio = audio._spawn(array.array(audio.array_type, np_audio.reshape((-1,))))
+    audio.export(path, format="wav")
+
+  def test_wav_file(self):
+    for num_channels in (1, 2, 8):
+      np_audio = self.create_np_audio(num_channels)
+      _, tmp_file = tempfile.mkstemp()
+      self.write_wave_file(np_audio, tmp_file)
+
+      self.assertFeature(
+          feature=features.Audio(
+              file_format="wav", shape=self.shape_for_channels(num_channels)
+          ),
+          shape=self.shape_for_channels(num_channels),
+          dtype=tf.int64,
+          tests=[
+              testing.FeatureExpectationItem(
+                  value=tmp_file,
+                  expected=np_audio,
+              ),
+              testing.FeatureExpectationItem(
+                  value=pathlib.Path(tmp_file),
+                  expected=np_audio,
+              ),
+          ],
+          test_attributes=dict(_file_format="wav",)
+      )
+
+  def test_file_object(self):
+    for num_channels in (1, 2, 8):
+      np_audio = self.create_np_audio(num_channels)
+      _, tmp_file = tempfile.mkstemp()
+      self.write_wave_file(np_audio, tmp_file)
+
+      class GFileWithSeekOnRead(tf.io.gfile.GFile):
+        """Wrapper around GFile which is reusable across multiple read() calls.
+
+        This is needed because assertFeature reuses the same
+        FeatureExpectationItem several times.
+        """
+
+        def read(self, *args, **kwargs):
+          data_read = super(GFileWithSeekOnRead, self).read(*args, **kwargs)
+          self.seek(0)
+          return data_read
+
+      with GFileWithSeekOnRead(tmp_file, "rb") as file_obj:
+        self.assertFeature(
+            feature=features.Audio(
+                file_format="wav", shape=self.shape_for_channels(num_channels)
+            ),
+            shape=self.shape_for_channels(num_channels),
+            dtype=tf.int64,
+            tests=[
+                testing.FeatureExpectationItem(
+                    value=file_obj,
+                    expected=np_audio,
+                ),
+            ],
+        )
 
   def test_sample_rate_property(self):
     self.assertEqual(features.Audio(sample_rate=1600).sample_rate, 1600)


### PR DESCRIPTION
## Description

This PR adds multichannel audio support to `tfds.features.Audio`, using the common shape convention of `(length, num_channels)`.
  
## Checklist
* [x] Address all TODO's
* [x] Add passing test(s)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
