### PR TITLE
Adding tests to avoid filenames as keys 

### DIFF
--- a/tensorflow_datasets/image_classification/cassava.py
+++ b/tensorflow_datasets/image_classification/cassava.py
@@ -102,4 +102,3 @@ class Cassava(tfds.core.GeneratorBasedBuilder):
             "label": label,
         }
         yield fname, record
-

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -368,20 +368,19 @@ class DatasetBuilderTestCase(
 
       original_generate_examples = builder._generate_examples
 
-      def new_generate_examples(self, *args, **kwargs):
+      def new_generate_examples(*args, **kwargs):
         records =  original_generate_examples(*args, **kwargs)
         #Validating the keys for any potential filenames
-        for key, _ in records:
-          raise ValueError(key)
+        for key, data in records:
           if str(self.example_dir) in key:
             err_msg = "The keys yielded by the '_generate_examples' method \
             contain user directory path, which might disrupt the deterministic\
             order of the generated examples. Please moify the dataset \
             generation script to resolve the issue."
             raise ValueError(err_msg)
-        yield records
+          yield key, data
 
-      with mock.patch.object(type(builder),
+      with mock.patch.object(builder,
                             '_generate_examples',
                             new_generate_examples):
         builder.download_and_prepare(download_config=download_config)

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -396,7 +396,12 @@ class DatasetBuilderTestCase(
         return original_generate_examples(self, *args, **kwargs)
 
       with mock.patch.object(builder, '_generate_examples', new_generate_examples):
-
+        keys, data = new_generate_examples(self)
+        if self.example_dir in keys:
+          err_msg = "The keys yielded by the '_generate_examples' method \
+          contain user directory path somewhere. Please change the dataset \
+          implementation to resolve the issue."
+          raise ValueError(err_msg)
 
   def _assertAsDataset(self, builder):
     split_to_checksums = {}  # {"split": set(examples_checksums)}

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -367,6 +367,9 @@ class DatasetBuilderTestCase(
       )
       builder.download_and_prepare(download_config=download_config)
 
+    with self._subTest("check_filename"):
+      self._assertNoFileName(builder)
+
     with self._subTest("as_dataset"):
       self._assertAsDataset(builder)
 
@@ -385,6 +388,9 @@ class DatasetBuilderTestCase(
 
     with self._subTest("config_description"):
       self._test_description_builder_config(builder)
+
+  def _assertNoFileName(self, builder):
+      original_generate_examples = builder._generate_examples
 
   def _assertAsDataset(self, builder):
     split_to_checksums = {}  # {"split": set(examples_checksums)}

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -368,19 +368,20 @@ class DatasetBuilderTestCase(
 
       original_generate_examples = builder._generate_examples
 
-      def new_generate_examples(*args, **kwargs):
+      def new_generate_examples(self, *args, **kwargs):
         records =  original_generate_examples(*args, **kwargs)
         #Validating the keys for any potential filenames
         for key, _ in records:
-          if self.example_dir in key:
+          raise ValueError(key)
+          if str(self.example_dir) in key:
             err_msg = "The keys yielded by the '_generate_examples' method \
             contain user directory path, which might disrupt the deterministic\
             order of the generated examples. Please moify the dataset \
             generation script to resolve the issue."
             raise ValueError(err_msg)
-        return records
+        yield records
 
-      with mock.patch.object(builder,
+      with mock.patch.object(type(builder),
                             '_generate_examples',
                             new_generate_examples):
         builder.download_and_prepare(download_config=download_config)

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -368,8 +368,8 @@ class DatasetBuilderTestCase(
 
       original_generate_examples = builder._generate_examples
 
-      def new_generate_examples(self, *args, **kwargs):
-        records =  original_generate_examples(self, *args, **kwargs)
+      def new_generate_examples(*args, **kwargs):
+        records =  original_generate_examples(*args, **kwargs)
         #Validating the keys for any potential filenames
         for key, _ in records:
           if self.example_dir in key:

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -25,7 +25,6 @@ from unittest import mock
 
 from absl.testing import parameterized
 import numpy as np
-import tensorflow.compat.v2 as tf
 
 from tensorflow_datasets.core import dataset_builder
 from tensorflow_datasets.core import dataset_info
@@ -37,6 +36,7 @@ from tensorflow_datasets.core.download import checksums
 from tensorflow_datasets.testing import feature_test_case
 from tensorflow_datasets.testing import test_utils
 
+import tensorflow.compat.v2 as tf
 # `os` module Functions for which tf.io.gfile equivalent should be preferred.
 FORBIDDEN_OS_FUNCTIONS = (
     "chmod",
@@ -371,7 +371,7 @@ class DatasetBuilderTestCase(
       def new_generate_examples(self, *args, **kwargs):
         records =  original_generate_examples(self, *args, **kwargs)
         #Validating the keys for any potential filenames
-        for key, data in records:
+        for key, _ in records:
           if self.example_dir in key:
             err_msg = "The keys yielded by the '_generate_examples' method \
             contain user directory path, which might disrupt the deterministic\
@@ -380,7 +380,9 @@ class DatasetBuilderTestCase(
             raise ValueError(err_msg)
         return records
 
-      with mock.patch.object(builder, '_generate_examples', new_generate_examples):
+      with mock.patch.object(builder,
+                            '_generate_examples',
+                            new_generate_examples):
         builder.download_and_prepare(download_config=download_config)
 
     with self._subTest("as_dataset"):

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -377,7 +377,7 @@ class DatasetBuilderTestCase(
             """\
             The keys yielded by the '_generate_examples' method
             contain user directory path, which might disrupt the
-            deterministic order of the generated examples. Please moify
+            deterministic order of the generated examples. Please modify
             the dataset generation script to resolve the issue."
             """)
             raise ValueError(err_msg)

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -373,10 +373,13 @@ class DatasetBuilderTestCase(
         #Validating the keys for any potential filenames
         for key, data in records:
           if str(self.example_dir) in key:
-            err_msg = "The keys yielded by the '_generate_examples' method \
-            contain user directory path, which might disrupt the deterministic\
-            order of the generated examples. Please moify the dataset \
-            generation script to resolve the issue."
+            err_msg = textwrap.dedent(
+            """\
+            The keys yielded by the '_generate_examples' method
+            contain user directory path, which might disrupt the
+            deterministic order of the generated examples. Please moify
+            the dataset generation script to resolve the issue."
+            """)
             raise ValueError(err_msg)
           yield key, data
 

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -367,9 +367,6 @@ class DatasetBuilderTestCase(
       )
       builder.download_and_prepare(download_config=download_config)
 
-    with self._subTest("check_filename"):
-      self._assertNoFileName(builder)
-
     with self._subTest("as_dataset"):
       self._assertAsDataset(builder)
 

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -392,6 +392,12 @@ class DatasetBuilderTestCase(
   def _assertNoFileName(self, builder):
       original_generate_examples = builder._generate_examples
 
+      def new_generate_examples(self, *args, **kwargs):
+        return original_generate_examples(self, *args, **kwargs)
+
+      with mock.patch.object(builder, '_generate_examples', new_generate_examples):
+
+
   def _assertAsDataset(self, builder):
     split_to_checksums = {}  # {"split": set(examples_checksums)}
     for split_name, expected_examples_number in self.SPLITS.items():

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -390,15 +390,17 @@ class DatasetBuilderTestCase(
       original_generate_examples = builder._generate_examples
 
       def new_generate_examples(self, *args, **kwargs):
-        return original_generate_examples(self, *args, **kwargs)
+        keys, data =  original_generate_examples(self, *args, **kwargs)
+        #Validating the keys for any potential filenames
+        for key in keys:
+          if self.example_dir in key:
+            err_msg = "The keys yielded by the '_generate_examples' method \
+            contain user directory path, which might disrupt the deterministic\
+            order of the generated examples. Please moify the dataset \
+            generation script to resolve the issue."
+            raise ValueError(err_msg)
 
       with mock.patch.object(builder, '_generate_examples', new_generate_examples):
-        keys, data = new_generate_examples(self)
-        if self.example_dir in keys:
-          err_msg = "The keys yielded by the '_generate_examples' method \
-          contain user directory path somewhere. Please change the dataset \
-          implementation to resolve the issue."
-          raise ValueError(err_msg)
 
   def _assertAsDataset(self, builder):
     split_to_checksums = {}  # {"split": set(examples_checksums)}


### PR DESCRIPTION
## Description

In reference to issue #2549 

`DatasetBuilderTestCase` needs to be updated so as to include tests to ensure that any of the keys yielded during a dataset generation does not contain any user directory path.
The PR is far from completed and therefore, under progress. 