### PR TITLE
[tensorflow_datasets/core/utils/gpath.py] Fix Windows support - `ModuleNotFoundError: No module named 'pwd'`

### DIFF
--- a/tensorflow_datasets/core/utils/gpath.py
+++ b/tensorflow_datasets/core/utils/gpath.py
@@ -106,7 +106,7 @@ class _GPath(pathlib.PurePath, type_utils.ReadWritePath):
 
   def expanduser(self: _P) -> _P:
     """Returns a new path with expanded `~` and `~user` constructs."""
-    return self._new(posixpath.expanduser(self._path_str))
+    return self._new(os.path.expanduser(self._path_str))
 
   def resolve(self: _P, strict: bool = False) -> _P:
     """Returns the abolute path."""


### PR DESCRIPTION
On Windows with Python 3.6 I get this error: https://github.com/SamuelMarks/ml-params-tensorflow/runs/1510316432
```
 "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\site-packages\tensorflow_datasets\core\load.py", line 344, in load
    dbuilder.download_and_prepare(**download_and_prepare_kwargs)
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\site-packages\tensorflow_datasets\core\dataset_builder.py", line 389, in download_and_prepare
    download_config=download_config)
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\site-packages\tensorflow_datasets\core\dataset_builder.py", line 828, in _make_download_manager
    dataset_name=self.name,
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\site-packages\tensorflow_datasets\core\download\download_manager.py", line 228, in __init__
    manual_dir and utils.as_path(manual_dir).expanduser()
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\site-packages\tensorflow_datasets\core\utils\gpath.py", line 86, in expanduser
    return self._new(posixpath.expanduser(self._path_str))
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\posixpath.py", line 248, in expanduser
    import pwd
ModuleNotFoundError: No module named 'pwd'
```

This PR has one obvious solution, to use [`os.path.expanduser`](https://docs.python.org/3/library/os.path.html#os.path.expanduser) instead of [`posixpath.expanduser`](https://github.com/python/cpython/blob/2c4c02f/Lib/posixpath.py#L228). One could also guard it like so:
```py
return self._new(getattr(os.path if sys.platform == 'win32' else posixpath, "expanduser")(self._path_str))
```