### PR TITLE
Add pyyaml dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,8 @@ TESTS_REQUIRE = [
     'tensorflow-data-validation;python_version<"3.7"',
     # TODO(b/142892342): Re-enable
     # 'tensorflow-docs @ git+https://github.com/tensorflow/docs#egg=tensorflow-docs',  # pylint: disable=line-too-long
+    # Catalog tests
+    'pyyaml',
 ]
 
 # Additional deps for formatting


### PR DESCRIPTION
Build catalog tests were recently added and it requires `yaml` module.

```
tensorflow_datasets\scripts\documentation\build_catalog_test.py:21: in <module>
    from tensorflow_datasets.scripts.documentation import build_catalog
tensorflow_datasets\scripts\documentation\build_catalog.py:30: in <module>
    import yaml
E   ModuleNotFoundError: No module named 'yaml'
=========================== short test summary info ===========================
ERROR tensorflow_datasets/scripts/documentation/build_catalog_test.py
============================== 1 error in 44.71s ==============================
```

So, added the `pyyaml` dependency in the setup file.

