### PR TITLE
Update URL and version for citrus leaves dataset

### DIFF
--- a/tensorflow_datasets/image_classification/citrus.py
+++ b/tensorflow_datasets/image_classification/citrus.py
@@ -55,6 +55,10 @@ class CitrusLeaves(tfds.core.GeneratorBasedBuilder):
   """Subset of the citrus dataset with just leaves."""
 
   VERSION = tfds.core.Version("0.1.1")
+  RELEASE_NOTES = {
+    "0.1.1": "Citrus Leaves dataset",
+    "0.1.2": "Website URL update"
+  }
 
   def _info(self):
     return tfds.core.DatasetInfo(

--- a/tensorflow_datasets/image_classification/citrus.py
+++ b/tensorflow_datasets/image_classification/citrus.py
@@ -47,7 +47,7 @@ Dataset URL: https://data.mendeley.com/datasets/3f83gxmv57/2
 License: http://creativecommons.org/licenses/by/4.0
 """
 
-_URL = "https://data.mendeley.com/datasets/3f83gxmv57/2/files/53398b67-6f0e-4a67-8384-e2b574b2ebf4/Citrus.zip"
+_URL = "https://data.mendeley.com/public-files/datasets/3f83gxmv57/files/53398b67-6f0e-4a67-8384-e2b574b2ebf4/file_downloaded"
 _LEAVES_LABELS = ["Black spot", "canker", "greening", "healthy"]
 
 

--- a/tensorflow_datasets/image_classification/citrus.py
+++ b/tensorflow_datasets/image_classification/citrus.py
@@ -54,7 +54,7 @@ _LEAVES_LABELS = ["Black spot", "canker", "greening", "healthy"]
 class CitrusLeaves(tfds.core.GeneratorBasedBuilder):
   """Subset of the citrus dataset with just leaves."""
 
-  VERSION = tfds.core.Version("0.1.1")
+  VERSION = tfds.core.Version("0.1.2")
   RELEASE_NOTES = {
     "0.1.1": "Citrus Leaves dataset",
     "0.1.2": "Website URL update"

--- a/tensorflow_datasets/url_checksums/citrus_leaves.txt
+++ b/tensorflow_datasets/url_checksums/citrus_leaves.txt
@@ -1,1 +1,1 @@
-https://data.mendeley.com/datasets/3f83gxmv57/2/files/53398b67-6f0e-4a67-8384-e2b574b2ebf4/Citrus.zip	66977095	9786d349b136a6e45359e64ababc857496d5909b313811707e0cb28a951977c7	Citrus.zip
+https://data.mendeley.com/public-files/datasets/3f83gxmv57/files/53398b67-6f0e-4a67-8384-e2b574b2ebf4/file_downloaded	66977095	9786d349b136a6e45359e64ababc857496d5909b313811707e0cb28a951977c7	Citrus.zip


### PR DESCRIPTION
In reference to issue Fix #2903
The website URL used for dataset generation was updated and the appropriate `version` and `release_notes` were added in the script. 
There was no change in the generated checksums.
The dataset is now generated and built successfully without any errors.