### PR TITLE
Recording checksums according to dataset structure

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -289,10 +289,7 @@ class DatasetBuilder(registered.RegisteredDataset):
       return cls.code_path.parent / "checksums.tsv"
     else:
       #Record checksums in the common folder for older structured datasets
-      chksm_path = utils.gpath.WindowsGPath(
-        'f:/tfds/datasets/tensorflow_datasets/url_checksums/' +
-        cls.name +
-        '.txt')
+      chksm_path = utils.tfds_path()/ 'url_checksums'/ (cls.name + '.txt')
       return chksm_path
 
   @utils.classproperty

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -285,8 +285,7 @@ class DatasetBuilder(registered.RegisteredDataset):
     # * To load the checksums (in url_infos)
     # * To save the checksums (in DownloadManager)
     #Checking whether the dataset follow the folder structure
-    path = str(cls.code_path.parent)
-    if path.split('\\')[-1] == cls.name:
+    if cls.code_path.parent.name == cls.name:
       return cls.code_path.parent / "checksums.tsv"
     else:
       #Record checksums in the common folder for older structured datasets

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -289,6 +289,7 @@ class DatasetBuilder(registered.RegisteredDataset):
     if path.split('\\')[-1] == cls.name:
       return cls.code_path.parent / "checksums.tsv"
     else:
+      #Record checksums in the common folder for older structured datasets
       chksm_path = utils.gpath.WindowsGPath(
         'f:/tfds/datasets/tensorflow_datasets/url_checksums/' +
         cls.name +

--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -284,7 +284,16 @@ class DatasetBuilder(registered.RegisteredDataset):
     # Used:
     # * To load the checksums (in url_infos)
     # * To save the checksums (in DownloadManager)
-    return cls.code_path.parent / "checksums.tsv"
+    #Checking whether the dataset follow the folder structure
+    path = str(cls.code_path.parent)
+    if path.split('\\')[-1] == cls.name:
+      return cls.code_path.parent / "checksums.tsv"
+    else:
+      chksm_path = utils.gpath.WindowsGPath(
+        'f:/tfds/datasets/tensorflow_datasets/url_checksums/' +
+        cls.name +
+        '.txt')
+      return chksm_path
 
   @utils.classproperty
   @classmethod


### PR DESCRIPTION
In reference to issue Fix #2905 
The checksums are now recorded in the dataset folder for the new structure and in the common `url_checksums` folder for other datasets.
It was successfuly tested with `citrus_leaves` and `wine_quality` dataset, storing the checksums at the right place.
[Note: `Citrus leaves` datasets currently has the wrong `url`, which was fixed in #2904 ]