### PR TITLE
Fix doc for pip install command for zsh

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -45,10 +45,10 @@ Install the development dependencies:
 
 ```sh
 pip install -e .  # Install minimal deps to use tensorflow_datasets
-pip install -e .[dev]  # Install all deps required for testing and development
+pip install -e ".[dev]"  # Install all deps required for testing and development
 ```
 
-Note there is also a `pip install -e .[tests-all]` to install all
+Note there is also a `pip install -e ".[tests-all]"` to install all
 dataset-specific deps.
 
 ### Visual Studio Code
@@ -115,7 +115,7 @@ likelly have to manually apply fixes afterward.
 yapf tensorflow_datasets/core/some_file.py
 ```
 
-Both `pylint` and `yapf` should have been installed with `pip install -e .[dev]`
+Both `pylint` and `yapf` should have been installed with `pip install -e ".[dev]"`
 but can also be manually installed with `pip install`. If you're using VS Code,
 those tools should be integrated in the UI.
 


### PR DESCRIPTION
The following command doesn't work on zsh (the z shell) and shows this
```
$ pip install -e .[dev]              
zsh: no matches found: .[dev]
```

This happens because `[` and `]` hold meaning and are special 
characters in zsh and thus need to be either escaped or quoted. 

I have tested that `pip install -e ".[dev]"` works on bash, 
zsh and csh. I believe that this will work with most other shells too.

