### PR TITLE
Update caltech101 URL and version

### DIFF
--- a/tensorflow_datasets/image_classification/caltech.py
+++ b/tensorflow_datasets/image_classification/caltech.py
@@ -37,7 +37,8 @@ This version contains image-level labels only. The original dataset also
 contains bounding boxes.
 """
 _LABELS_FNAME = "image_classification/caltech101_labels.txt"
-_URL = "http://www.vision.caltech.edu/Image_Datasets/Caltech101/"
+_URL = "https://drive.google.com/uc?export=download&id=137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp"
+_HOMEPAGE = "http://www.vision.caltech.edu/Image_Datasets/Caltech101/"
 _IMAGES_FNAME = "101_ObjectCategories.tar.gz"
 _TRAIN_POINTS_PER_CLASS = 30
 
@@ -45,9 +46,10 @@ _TRAIN_POINTS_PER_CLASS = 30
 class Caltech101(tfds.core.GeneratorBasedBuilder):
   """Caltech-101."""
 
-  VERSION = tfds.core.Version("3.0.0")
+  VERSION = tfds.core.Version("3.0.1")
   RELEASE_NOTES = {
       "3.0.0": "New split API (https://tensorflow.org/datasets/splits)",
+      "3.0.1": "Website URL update",
   }
 
   def _info(self):
@@ -61,12 +63,12 @@ class Caltech101(tfds.core.GeneratorBasedBuilder):
             "image/file_name": tfds.features.Text(),  # E.g. 'image_0001.jpg'.
         }),
         supervised_keys=("image", "label"),
-        homepage=_URL,
+        homepage=_HOMEPAGE,
         citation=_CITATION
         )
 
   def _split_generators(self, dl_manager):
-    path = dl_manager.download_and_extract(os.path.join(_URL, _IMAGES_FNAME))
+    path = dl_manager.download_and_extract(_URL)
     return [
         tfds.core.SplitGenerator(
             name=tfds.Split.TRAIN,

--- a/tensorflow_datasets/image_classification/caltech.py
+++ b/tensorflow_datasets/image_classification/caltech.py
@@ -39,7 +39,6 @@ contains bounding boxes.
 _LABELS_FNAME = "image_classification/caltech101_labels.txt"
 _URL = "https://drive.google.com/uc?export=download&id=137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp"
 _HOMEPAGE = "http://www.vision.caltech.edu/Image_Datasets/Caltech101/"
-_IMAGES_FNAME = "101_ObjectCategories.tar.gz"
 _TRAIN_POINTS_PER_CLASS = 30
 
 

--- a/tensorflow_datasets/url_checksums/caltech101.txt
+++ b/tensorflow_datasets/url_checksums/caltech101.txt
@@ -1,1 +1,1 @@
-http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz	131740031	af6ece2f339791ca20f855943d8b55dd60892c0a25105fcd631ee3d6430f9926	view
+https://drive.google.com/uc?export=download&id=137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp	131740031	af6ece2f339791ca20f855943d8b55dd60892c0a25105fcd631ee3d6430f9926	view


### PR DESCRIPTION
Closes #2925 

I've updated the download URL and bumped the dataset version number.
The new URL is reachable from the [homepage](http://www.vision.caltech.edu/Image_Datasets/Caltech101/).
The datasets downloads without problems now.