### PR TITLE
Fix downloader bug

### DIFF
--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -92,7 +92,7 @@ def _filename_from_content_disposition(
         f'Error while parsing filename for: {content_disposition}\n'
         f'Multiple filename detected: {list(match)}'
     )
-  return match[0].rstrip()
+  return os.path.basename(match[0].rstrip())
 
 
 def _get_filename(response: Response) -> str:

--- a/tensorflow_datasets/core/download/downloader_test.py
+++ b/tensorflow_datasets/core/download/downloader_test.py
@@ -192,6 +192,11 @@ _CONTENT_DISPOSITION_FILENAME_PAIRS = [
             filename*= UTF-8''%e2%82%ac%20rates.zip""",
         None,
     ),
+    # Give only file base name when directory path is given
+    (
+      'inline;filename=path/to/dir/f-name.png;filename*=UTF-8',
+      'f-name.png'
+    )
 ]
 
 


### PR DESCRIPTION
This fixes #2923 

Some websites return slashes(i.e. path with directory) in the filename within the content-disposition field
This [RFC](https://tools.ietf.org/html/rfc1806) properly defines the grammar for content-disposition.

Thus to properly extract the filename we take only the base filename from the value we get from content-disposition