### PR TITLE
Fix html tag visualization for Ragged Tensor

### DIFF
--- a/tensorflow_datasets/core/as_dataframe.py
+++ b/tensorflow_datasets/core/as_dataframe.py
@@ -82,9 +82,14 @@ class ColumnInfo:
     elif sequence_rank > 1:
       repr_fn = feature.repr_html_ragged
 
-    def repr_fn_with_debug(val):  # Wrap repr_fn to add debug info
+    def repr_fn_wrapper(val):  # Wrap repr_fn to add debug info & fix html tags
       try:
-        return repr_fn(val)
+        html_repr =  repr_fn(val)
+        # Replace '<' and '>' characters in the html with '&lt;' and '&gt;'
+        # so that they are not confused as html tags when rendering
+        # Inspired from pandas _repr_html_
+        html_repr = html_repr.replace('<', r'&lt;', 1).replace('>', r'&gt;', 1)
+        return html_repr
       except Exception as e:  # pylint: disable=broad-except
         err_msg = (
             f'HTML formatting of column {name} failed:\n'
@@ -95,7 +100,7 @@ class ColumnInfo:
 
     return ColumnInfo(
         name='/'.join(path),
-        format_fn=repr_fn_with_debug,
+        format_fn=repr_fn_wrapper,
     )
 
 

--- a/tensorflow_datasets/core/as_dataframe.py
+++ b/tensorflow_datasets/core/as_dataframe.py
@@ -82,14 +82,9 @@ class ColumnInfo:
     elif sequence_rank > 1:
       repr_fn = feature.repr_html_ragged
 
-    def repr_fn_wrapper(val):  # Wrap repr_fn to add debug info & fix html tags
+    def repr_fn_with_debug(val):  # Wrap repr_fn to add debug info
       try:
-        html_repr =  repr_fn(val)
-        # Replace '<' and '>' characters in the html with '&lt;' and '&gt;'
-        # so that they are not confused as html tags when rendering
-        # Inspired from pandas _repr_html_
-        html_repr = html_repr.replace('<', r'&lt;', 1).replace('>', r'&gt;', 1)
-        return html_repr
+        return repr_fn(val)
       except Exception as e:  # pylint: disable=broad-except
         err_msg = (
             f'HTML formatting of column {name} failed:\n'
@@ -100,7 +95,7 @@ class ColumnInfo:
 
     return ColumnInfo(
         name='/'.join(path),
-        format_fn=repr_fn_wrapper,
+        format_fn=repr_fn_with_debug,
     )
 
 

--- a/tensorflow_datasets/core/features/feature.py
+++ b/tensorflow_datasets/core/features/feature.py
@@ -18,6 +18,7 @@
 import abc
 import collections
 import functools
+import html
 import json
 import os
 from typing import Dict, Type, TypeVar
@@ -731,7 +732,9 @@ def _repr_html(ex) -> str:
     # Do not print individual values for array as it is slow
     # TODO(tfds): We could display a snippet, like the first/last tree items
     return f'{type(ex).__qualname__}(shape={ex.shape}, dtype={ex.dtype})'
-  return repr(ex)
+
+  # Escape symbols which might have special meaning in HTML like '<', '>'
+  return html.escape(repr(ex))
 
 
 def _has_shape_ambiguity(in_shape: Shape, out_shape: Shape) -> bool:


### PR DESCRIPTION
Fixes #2966 

On investigating the issue, it turns out that when the data is a RaggedTensor, the `repr_html_ragged` does get called which in turn calls the `_repr_` of ReggedTensor, which contains `<` and `>` symbols, which are then parsed as HTML when rendering.

Hence, the fix was to replace `<` and `>` characters in the HTML with `&lt;` and `&gt;` which is also what is done somewhere in pandas `_repr_html_`
