### PR TITLE
Updated extractor to show better progress bar with number of files

### DIFF
--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -253,6 +253,16 @@ def iter_gzip(arch_f):
     yield ('', gzip_)  # No inner file.
 
 
+class _Bzip2File(_ArchiveFile):
+
+  def get_num_files(self) -> int:
+    return 1
+
+  def get_iter(self):
+    with _open_or_pass(self.arch_f) as fobj:
+      bz2_ = bz2.BZ2File(filename=fobj)
+      yield ('', bz2_)  # No inner file.
+
 def iter_bzip2(arch_f):
   with _open_or_pass(arch_f) as fobj:
     bz2_ = bz2.BZ2File(filename=fobj)

--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -237,6 +237,15 @@ def iter_tar(arch_f, stream=False):
 def iter_tar_stream(arch_f):
   return iter_tar(arch_f, stream=True)
 
+class _GzipFile(_ArchiveFile):
+
+  def get_num_files(self) -> int:
+    return 1
+
+  def get_iter(self):
+    with _open_or_pass(self.arch_f) as fobj:
+      gzip_ = gzip.GzipFile(fileobj=fobj)
+      yield ('', gzip_)  # No inner file.
 
 def iter_gzip(arch_f):
   with _open_or_pass(arch_f) as fobj:

--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -139,6 +139,18 @@ def _open_or_pass(path_or_fobj):
     yield path_or_fobj
 
 
+class _ArchiveFile:
+
+  def __init__(self, arch_f) -> None:
+    self.arch_f = arch_f
+
+  def get_num_files(self) -> int:
+    raise NotImplementedError()
+
+  def get_iter(self):
+    raise NotImplementedError()
+
+
 def iter_tar(arch_f, stream=False):
   """Iter over tar archive, yielding (path, object-like) tuples.
 

--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -158,6 +158,7 @@ class _TarFile(_ArchiveFile):
 
   def get_num_files(self) -> int:
     with _open_or_pass(self.arch_f) as fobj:
+      # Opened in stream mode since it is faster and we stream once
       tar = tarfile.open(fileobj=fobj, mode='r|*')
       num_files = sum(1 for member in tar if member.isfile())
       return num_files
@@ -241,14 +242,15 @@ class _ZipFile(_ArchiveFile):
 
 
 _EXTRACT_METHODS = {
-    resource_lib.ExtractMethod.BZIP2        : _Bzip2File,
-    resource_lib.ExtractMethod.GZIP         : _GzipFile,
-    resource_lib.ExtractMethod.TAR          : _TarFile,
-    resource_lib.ExtractMethod.TAR_GZ       : _TarFile,
+    resource_lib.ExtractMethod.BZIP2: _Bzip2File,
+    resource_lib.ExtractMethod.GZIP: _GzipFile,
+    resource_lib.ExtractMethod.TAR: _TarFile,
+    resource_lib.ExtractMethod.TAR_GZ: _TarFile,
     resource_lib.ExtractMethod.TAR_GZ_STREAM: _TarFile,
-    resource_lib.ExtractMethod.TAR_STREAM   : _TarFile,
-    resource_lib.ExtractMethod.ZIP          : _ZipFile,
+    resource_lib.ExtractMethod.TAR_STREAM: _TarFile,
+    resource_lib.ExtractMethod.ZIP: _ZipFile,
 }
+
 
 def _get_archive_file(
     path: utils.PathLike,

--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -347,4 +347,6 @@ def iter_archive(
     raise ValueError(
         f'Cannot `iter_archive` over {path}. Invalid or unrecognised archive.'
     )
-  return _EXTRACT_METHODS[method](path)  # pytype: disable=bad-return-type
+  archive_file  = _get_archive_file(path, method)
+  kwargs = {'stream': True} if method.name.endswith('STREAM') else {}
+  return archive_file.get_iter(**kwargs)

--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -141,6 +141,7 @@ def _open_or_pass(path_or_fobj):
 
 
 class _ArchiveFile:
+  """Base class for common Archive file functionality"""
 
   def __init__(self, arch_f) -> None:
     self.arch_f = arch_f
@@ -153,6 +154,7 @@ class _ArchiveFile:
 
 
 class _TarFile(_ArchiveFile):
+  """ArchiveFile for tar files"""
 
   def get_num_files(self) -> int:
     with _open_or_pass(self.arch_f) as fobj:
@@ -193,6 +195,7 @@ class _TarFile(_ArchiveFile):
 
 
 class _GzipFile(_ArchiveFile):
+  """ArchiveFile for gzip(.gz) files"""
 
   def get_num_files(self) -> int:
     return 1
@@ -204,6 +207,7 @@ class _GzipFile(_ArchiveFile):
 
 
 class _Bzip2File(_ArchiveFile):
+  """ArchiveFile for bzip2(.bz2) files"""
 
   def get_num_files(self) -> int:
     return 1
@@ -215,6 +219,7 @@ class _Bzip2File(_ArchiveFile):
 
 
 class _ZipFile(_ArchiveFile):
+  """ArchiveFile for zip files"""
 
   def get_num_files(self) -> int:
     with _open_or_pass(self.arch_f) as fobj:

--- a/tensorflow_datasets/core/download/extractor.py
+++ b/tensorflow_datasets/core/download/extractor.py
@@ -313,6 +313,22 @@ _EXTRACT_METHODS = {
     resource_lib.ExtractMethod.ZIP: iter_zip,
 }
 
+_ARCHIVE_CLASS = {
+    resource_lib.ExtractMethod.BZIP2        : _Bzip2File,
+    resource_lib.ExtractMethod.GZIP         : _GzipFile,
+    resource_lib.ExtractMethod.TAR          : _TarFile,
+    resource_lib.ExtractMethod.TAR_GZ       : _TarFile,
+    resource_lib.ExtractMethod.TAR_GZ_STREAM: _TarFile,
+    resource_lib.ExtractMethod.TAR_STREAM   : _TarFile,
+    resource_lib.ExtractMethod.ZIP          : _ZipFile,
+}
+
+def _get_archive_file(
+    path: utils.PathLike,
+    method: resource_lib.ExtractMethod,
+) -> _ArchiveFile:
+  return _ARCHIVE_CLASS[method](path)
+
 
 def iter_archive(
     path: utils.PathLike,


### PR DESCRIPTION
Fixes #2979

I looked into this issue and it required a bit of restructuring to implement.

Previously we mapped extract methods directly to `iter_<type>` but it was difficult to accommodate 'number of files' with it.
So this PR creates a base class which each extraction type inherits from and implements `get_num_files` and `get_iter`.

There are some points I would like comments on

- Currently, I have opened the file once in `get_num_files` and then again when `get_iter` is called. Should I try to optimize this to not open twice but store the opened file when the object is initialized? This might be done by making _ArchiveFile itself a context manager, and close the file when its context ends. This would also require manually calling `__enter__` and `__exit__` of `_open_or_pass` in `_ArchiveFile`

- Currently in the base class, I have used `raise NotImplementedError()`. I can also use `abc.ABC` for the same. Would that be better?

- There is some performance hit to get the number of files, which scales linearly with file size. Should there be an option to opt-out? It is still much less compared to the actual extraction time, so perhaps it is not that much of an issue.

- The other `iter_<type>` functions were removed except for `iter_archive` which is the common one. Its implementation was modified to accommodate the new code. I thought it better not to remove it since it is used by some datasets directly. Is this okay?

- Mentioned inline

Thank you