### PR TITLE
Added public API to enable tqdm corresponding to the one for closing it

### DIFF
--- a/tensorflow_datasets/core/utils/tqdm_utils.py
+++ b/tensorflow_datasets/core/utils/tqdm_utils.py
@@ -94,7 +94,7 @@ def async_tqdm(*args, **kwargs):
 
 
 def disable_progress_bar():
-  """Disabled Tqdm progress bar.
+  """Disables Tqdm progress bar.
 
   Usage:
 
@@ -104,6 +104,16 @@ def disable_progress_bar():
   global _active
   _active = False
 
+def enable_progress_bar():
+  """Enables Tqdm progress bar.
+
+  Usage:
+
+  tfds.enable_progress_bar()
+  """
+  # Replace tqdm
+  global _active
+  _active = True
 
 @contextlib.contextmanager
 def _async_tqdm(*args, **kwargs):

--- a/tensorflow_datasets/public_api.py
+++ b/tensorflow_datasets/public_api.py
@@ -41,6 +41,7 @@ from tensorflow_datasets.core.utils import type_utils as typing
 from tensorflow_datasets.core.utils.gcs_utils import is_dataset_on_gcs
 from tensorflow_datasets.core.utils.read_config import ReadConfig
 from tensorflow_datasets.core.utils.tqdm_utils import disable_progress_bar
+from tensorflow_datasets.core.utils.tqdm_utils import enable_progress_bar
 from tensorflow_datasets.core.visualization import show_examples
 from tensorflow_datasets.core.visualization import show_statistics
 from tensorflow_datasets.version import __version__
@@ -63,6 +64,7 @@ __all__ = [
     "builder_cls",
     "decode",
     "disable_progress_bar",
+    "enable_progress_bar",
     "download",
     "even_splits",
     "features",


### PR DESCRIPTION
Progress bar once disabled, cannot be enabled again. This PR adds an API to do so.

I had some use case for this feature myself and had added it locally. Thought I'd upstream it.