### PR TITLE
Support custom BuilderConfig in testing

### DIFF
--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -312,15 +312,15 @@ class DatasetBuilderTestCase(
                                f'Available: {list(self.builder.builder_configs)}')
 
     configs = self.builder.BUILDER_CONFIGS
-    print("Total configs: %d" % len(configs))
+    print(f"Total configs: {len(configs)}")
     if configs:
       for config in configs:
         # Skip the configs that are not in the list.
         if (len(configs_to_test) > 0 and config.name not in configs_to_test):  # pylint: disable=unsupported-membership-test
-          print("Skipping config %s" % config.name)
+          print(f"Skipping config {config.name}")
           continue
         with self._subTest(config.name):
-          print("Testing config %s" % config.name)
+          print(f"Testing config {config.name}")
           builder = self._make_builder(config=config)
           self._download_and_prepare_as_dataset(builder)
     else:

--- a/tensorflow_datasets/testing/dataset_builder_testing.py
+++ b/tensorflow_datasets/testing/dataset_builder_testing.py
@@ -300,8 +300,13 @@ class DatasetBuilderTestCase(
   @test_utils.run_in_graph_and_eager_modes()
   def test_download_and_prepare_as_dataset(self):
     # If configs specified, ensure they are all valid
+    test_config_names = []  # extract names of all builder configs to test
+
     if self.BUILDER_CONFIG_NAMES_TO_TEST:
       for config in self.BUILDER_CONFIG_NAMES_TO_TEST:  # pylint: disable=not-an-iterable
+        if isinstance(config, dataset_builder.BuilderConfig):
+          config = config.name
+        test_config_names.append(config)
         assert config in self.builder.builder_configs, (
             "Config %s specified in test does not exist. Available:\n%s" % (
                 config, list(self.builder.builder_configs)))
@@ -311,8 +316,8 @@ class DatasetBuilderTestCase(
     if configs:
       for config in configs:
         # Skip the configs that are not in the list.
-        if (self.BUILDER_CONFIG_NAMES_TO_TEST is not None and
-            (config.name not in self.BUILDER_CONFIG_NAMES_TO_TEST)):  # pylint: disable=unsupported-membership-test
+        if (len(test_config_names) > 0 and
+            (config.name not in test_config_names)):  # pylint: disable=unsupported-membership-test
           print("Skipping config %s" % config.name)
           continue
         with self._subTest(config.name):


### PR DESCRIPTION
## Support custom `BuilderConfig` when testing datasets 

Fixes #2969 

Task:
 * [x] `tfds.testing.DatasetBuilderTestCase.BUILDER_CONFIG_NAMES_TO_TEST ` should support `BuilderConfig`