### PR TITLE
Fix ag_news_subset checksum

### DIFF
--- a/tensorflow_datasets/url_checksums/ag_news_subset.txt
+++ b/tensorflow_datasets/url_checksums/ag_news_subset.txt
@@ -1,1 +1,1 @@
-https://drive.google.com/uc?export=download&id=0Bz8a_Dbh9QhbUDNpeUdjb0wxRms	11784327	4E2FC37D369E6E317A8B62D0D2F11D379F8C3DDE60C07C35A46B069A246498AD	ag_news_csv.tar.gz
+https://drive.google.com/uc?export=download&id=0Bz8a_Dbh9QhbUDNpeUdjb0wxRms	11784327	4e2fc37d369e6e317a8b62d0d2f11d379f8c3dde60c07c35a46b069a246498ad	ag_news_csv.tar.gz


### PR DESCRIPTION
Fixes #3004 

The checksum hasn't changed, but the currently recorded checksum uses uppercase letters when it should be lowercase, thus giving the mismatch error.