### PR TITLE
Serialize other ints without cating to int64

### DIFF
--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -134,7 +134,11 @@ def _item_to_tf_feature(item, tensor_info):
 
   v = v.flatten()  # Convert v into a 1-d array
   if np.issubdtype(v.dtype, np.integer):
-    return tf.train.Feature(int64_list=tf.train.Int64List(value=v))
+    if tensor_info.dtype == tf.int64:
+      return tf.train.Feature(int64_list=tf.train.Int64List(value=v))
+    else:
+      v = [tf.compat.as_bytes(x) for x in str(v)]
+      return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
   elif np.issubdtype(v.dtype, np.floating):
     return tf.train.Feature(float_list=tf.train.FloatList(value=v))
   elif tensor_info.dtype == tf.string:

--- a/tensorflow_datasets/core/example_serializer_test.py
+++ b/tensorflow_datasets/core/example_serializer_test.py
@@ -227,6 +227,17 @@ class ExampleSerializerTest(testing.SubTestCase):
     ):
       example_serializer._dict_to_tf_example(example_data, tensor_info)
 
+  def test_item_to_tf_feature_int16_check(self):
+    # Test int16 check in _item_to_tf_feature raises ValueError.
+    example_item = [1, 2, 3, 4, 5]
+    tensor_info = feature_lib.TensorInfo(shape=(5,), dtype=tf.int16)
+    example_serializer._item_to_tf_feature(example_item, tensor_info)
+    ex = np.array(example_item, dtype=tensor_info.dtype.as_numpy_dtype).flatten()
+    ex = [tf.compat.as_bytes(x) for x in str(ex)]
+    ex = tf.train.Feature(bytes_list=tf.train.BytesList(value=ex))
+    out = example_serializer._item_to_tf_feature(example_item, tensor_info)
+    self.assertEqual(out, ex)
+
 
 if __name__ == '__main__':
   testing.test_main()


### PR DESCRIPTION
### Serialize other ints without cating to `int64`

Fixes: #3015 

Status: WIP

Tasks:
[ ] serialize other ints without cating to `int64`
[ ] make sure that the `tf.string` > `tf.int16` decoding do not impact the pipeline performances.
[ ] check if it works with `tensorflow_data_validation`