### PR TITLE
Parallelize list_builders function call

### DIFF
--- a/tensorflow_datasets/core/community/register_path.py
+++ b/tensorflow_datasets/core/community/register_path.py
@@ -162,6 +162,6 @@ def _iter_builder_names(
   # Note: `data_dir` might contain non-dataset folders, but checking
   # individual dataset would have significant performance drop, so
   # this is an acceptable trade-of
-  pool = ThreadPool(10)
-  for result in pool.starmap(_parallel, ns2data_dir.items()):
-    yield from result
+  with ThreadPool(4) as pool:
+    for result in pool.starmap(_parallel, ns2data_dir.items()):
+      yield from result

--- a/tensorflow_datasets/core/community/register_path.py
+++ b/tensorflow_datasets/core/community/register_path.py
@@ -149,8 +149,7 @@ def _iter_builder_names(
     ns2data_dir: Dict[str, utils.ReadOnlyPath],
 ) -> Iterator[str]:
   """Yields the `ns:name` dataset names."""
-  FILTERED_DIRNAME = frozenset(('downloads',))
-  # pylint: disable=invalid-name
+  FILTERED_DIRNAME = frozenset(('downloads',))# pylint: disable=invalid-name
   # For better performances, could try to load all namespaces asynchonously
 
   def _parallel(ns_name, data_dir):

--- a/tensorflow_datasets/core/community/register_path.py
+++ b/tensorflow_datasets/core/community/register_path.py
@@ -158,11 +158,11 @@ def _iter_builder_names(
     str(utils.DatasetName(namespace=ns_name, name=builder_dir.name))
     for builder_dir in _maybe_iterdir(data_dir)
     if not builder_dir.name in FILTERED_DIRNAME and
-    if naming.is_valid_dataset_name(builder_dir.name)
+    naming.is_valid_dataset_name(builder_dir.name)
     ]
   # Note: `data_dir` might contain non-dataset folders, but checking
   # individual dataset would have significant performance drop, so
   # this is an acceptable trade-of
   pool = ThreadPool(10)
-  for result in pool.map(_parallel, ns2data_dir.items()):
+  for result in pool.starmap(_parallel, ns2data_dir.items()):
     yield from result


### PR DESCRIPTION
`tfds.list_builders` has been parallelized using `multiprocessing.dummy.pool` with multiple threads as the underlying function is IO bound.

Closes #3036 