### PR TITLE
Fix CelebA download links

### DIFF
--- a/tensorflow_datasets/image/celeba.py
+++ b/tensorflow_datasets/image/celeba.py
@@ -28,6 +28,7 @@ import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
 IMG_ALIGNED_DATA = ("https://drive.google.com/u/0/uc?export=download&confirm=_OTb&id=0B7EVK8r0v71pZjFTYXZWM3FlRnM")
+
 EVAL_LIST = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pY0NSMzRuSXJEVkk")
 # Landmark coordinates: left_eye, right_eye etc.
 LANDMARKS_DATA = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pd0FJY3Blby1HUTQ")

--- a/tensorflow_datasets/image/celeba.py
+++ b/tensorflow_datasets/image/celeba.py
@@ -27,17 +27,13 @@ import tensorflow.compat.v2 as tf
 
 import tensorflow_datasets.public_api as tfds
 
-IMG_ALIGNED_DATA = ("https://drive.google.com/uc?export=download&"
-                    "id=0B7EVK8r0v71pZjFTYXZWM3FlRnM")
-EVAL_LIST = ("https://drive.google.com/uc?export=download&"
-             "id=0B7EVK8r0v71pY0NSMzRuSXJEVkk")
+IMG_ALIGNED_DATA = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pZjFTYXZWM3FlRnM")
+EVAL_LIST = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pY0NSMzRuSXJEVkk")
 # Landmark coordinates: left_eye, right_eye etc.
-LANDMARKS_DATA = ("https://drive.google.com/uc?export=download&"
-                  "id=0B7EVK8r0v71pd0FJY3Blby1HUTQ")
+LANDMARKS_DATA = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pd0FJY3Blby1HUTQ")
 
 # Attributes in the image (Eyeglasses, Mustache etc).
-ATTR_DATA = ("https://drive.google.com/uc?export=download&"
-             "id=0B7EVK8r0v71pblRyaVFSWGxPY0U")
+ATTR_DATA = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pblRyaVFSWGxPY0U")
 
 LANDMARK_HEADINGS = ("lefteye_x lefteye_y righteye_x righteye_y "
                      "nose_x nose_y leftmouth_x leftmouth_y rightmouth_x "

--- a/tensorflow_datasets/image/celeba.py
+++ b/tensorflow_datasets/image/celeba.py
@@ -27,7 +27,7 @@ import tensorflow.compat.v2 as tf
 
 import tensorflow_datasets.public_api as tfds
 
-IMG_ALIGNED_DATA = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pZjFTYXZWM3FlRnM")
+IMG_ALIGNED_DATA = ("https://drive.google.com/u/0/uc?export=download&confirm=_OTb&id=0B7EVK8r0v71pZjFTYXZWM3FlRnM")
 EVAL_LIST = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pY0NSMzRuSXJEVkk")
 # Landmark coordinates: left_eye, right_eye etc.
 LANDMARKS_DATA = ("https://drive.google.com/uc?export=download&id=0B7EVK8r0v71pd0FJY3Blby1HUTQ")


### PR DESCRIPTION
Closes #2406 
The old download link were valid but however, they were poorly formatted due to which it changed he actual URL (due to the inverted commas in between line break). The formatting has been fixed now.
However, it still causes some error which might have to do with the bug reported in #3054. It might get resolved after #3055 has merged