### PR TITLE
Fix librispeech wrong path

### DIFF
--- a/tensorflow_datasets/audio/librispeech.py
+++ b/tensorflow_datasets/audio/librispeech.py
@@ -118,7 +118,7 @@ def _generate_librispeech_examples(directory):
   transcripts_glob = os.path.join(directory, "LibriSpeech", "*/*/*/*.txt")
   for transcript_file in tf.io.gfile.glob(transcripts_glob):
     path = os.path.dirname(transcript_file)
-    with tf.io.gfile.GFile(os.path.join(path, transcript_file)) as f:
+    with tf.io.gfile.GFile(transcript_file) as f:
       for line in f:
         line = line.strip()
         key, transcript = line.split(" ", 1)


### PR DESCRIPTION
A separate PR for the librispeech.py fix since the original author of #2181 hasn't responded for a while
