### PR TITLE
Fix multiple tqdm bar issue

### DIFF
--- a/tensorflow_datasets/core/utils/tqdm_utils.py
+++ b/tensorflow_datasets/core/utils/tqdm_utils.py
@@ -147,7 +147,6 @@ def _async_tqdm(*args, **kwargs):
     pbar = _TqdmPbarAsync(pbar)
     yield pbar
     pbar.clear()  # pop pbar from the active list of pbar
-    print()  # Avoid the next log to overlapp with the bar
 
 
 class _TqdmPbarAsync(object):


### PR DESCRIPTION
Fixes #3110  

In my testing, no overlap occurs after removing the print statement.

**New log**:
```python
Downloading and preparing dataset 11.06 MiB (download: 11.06 MiB, generated: 21.00 MiB, total: 32.06 MiB) to /home/jatin/tensorflow_datasets/mnist/3.0.1...
INFO[dataset_builder.py]: Dataset mnist is hosted on GCS. It will automatically be downloaded to your
local data directory. If you'd instead prefer to read directly from our public
GCS bucket (recommended if you're running on GCP), you can instead pass
`try_gcs=True` to `tfds.load` or set `data_dir=gs://tfds-data/datasets`.

Dl Completed...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.49s/ file]
INFO[dataset_info.py]: Load dataset info from /home/jatin/tensorflow_datasets/mnist/3.0.1.incompleteGDRWQD
INFO[dataset_info.py]: Field info.citation from disk and from code do not match. Keeping the one from code.
INFO[dataset_info.py]: Field info.splits from disk and from code do not match. Keeping the one from code.
INFO[dataset_info.py]: Field info.module_name from disk and from code do not match. Keeping the one from code.
Dataset mnist downloaded and prepared to /home/jatin/tensorflow_datasets/mnist/3.0.1. Subsequent calls will reuse this data.
INFO[build.py]: Dataset generation complete...
```