### PR TITLE
Fix radon dataset for windows

### DIFF
--- a/tensorflow_datasets/structured/radon.py
+++ b/tensorflow_datasets/structured/radon.py
@@ -21,12 +21,13 @@ from __future__ import print_function
 
 import collections
 import os
+import six.moves.urllib as urllib
 
 import numpy as np
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
-BASE_URL = 'http://www.stat.columbia.edu/~gelman/arm/examples/radon'
+BASE_URL = 'http://www.stat.columbia.edu/~gelman/arm/examples/radon/'
 
 _CITATION = """\
 @book{GelmanHill:2007,
@@ -113,8 +114,8 @@ class Radon(tfds.core.GeneratorBasedBuilder):
   def _split_generators(self, dl_manager):
     """Returns SplitGenerators."""
     paths = dl_manager.download({
-        'file_path_srrs2': os.path.join(BASE_URL, 'srrs2.dat'),
-        'file_path_cty': os.path.join(BASE_URL, 'cty.dat')
+        'file_path_srrs2': urllib.parse.urljoin(BASE_URL, 'srrs2.dat'),
+        'file_path_cty': urllib.parse.urljoin(BASE_URL, 'cty.dat')
     })
     return [
         tfds.core.SplitGenerator(


### PR DESCRIPTION
Closes #3112 
The `os.path.join` used in the `radon` dataset script for joining the url components yields `'http://www.stat.columbia.edu/~gelman/arm/examples/radon\\cty.dat'` and thus, gives an error while downloading due to the irregular slashing. 

Using `urllib` instead of the usual 'os` solves the problem.