### PR TITLE
Add `--namespace` and `--search` flags to `tfds list` CLI

### DIFF
--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -18,7 +18,11 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: 
   )
 
   new_parser.add_argument(
-    ''
+    '--search',
+    type=str,
+    nargs='+',
+    dest='search_query',
+    help='Search flag to display all datasets containing the searched query'
   )
   new_parser.set_defaults(subparser_fn=_list_datasets)
 

--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -13,11 +13,13 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: 
   new_parser.add_argument(
     '--namespace',
     type=str,
-    nargs='*',
-    dest='namespace_keyword',
+    nargs='+',
     help='Namespace flag for displaying datasets from given namespace'
   )
 
+  new_parser.add_argument(
+    ''
+  )
   new_parser.set_defaults(subparser_fn=_list_datasets)
 
 

--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -21,7 +21,7 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: 
   new_parser.add_argument(
     '--search',
     type=str,
-    nargs='+',
+    nargs=1,
     dest='search_query',
     help='Search flag to display all datasets containing the searched query'
   )
@@ -49,7 +49,7 @@ def list_namespace_datasets(namespace: str) -> None:
   if visibility.DatasetType.COMMUNITY_PUBLIC.is_available():
     datasets = community.community_register.list_builders()
 
-  print(f"Datasets associated with `{namespace[0]}` namespace:")
+  print(f"Datasets associated with `{namespace[0]}` namespace:\n")
   #Getting all datasets for given namespace
   for dataset in datasets:
     if dataset.split(':')[0] == namespace[0]:
@@ -59,3 +59,17 @@ def list_namespace_datasets(namespace: str) -> None:
 
   if not dataset_found:
     print("No datasets match given namespace.")
+
+def search_datasets(search_query: str) -> None:
+  datasets = load.list_builders()
+  dataset_found = False
+  #Search for matching datasets
+  print(f"Datasets resembling `{search_query[0]}`:\n")
+  for dataset in datasets:
+    if search_query[0] in dataset:
+      print(dataset)
+      if not dataset_found:
+        dataset_found = True
+
+  if not dataset_found:
+    print("No datasets match given query.")

--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -1,0 +1,23 @@
+
+"""`tfds list` command."""
+
+import argparse
+
+from tensorflow_datasets.core import load
+
+
+def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: disable=protected-access
+  """Add subparser for `list` command."""
+  new_parser = parsers.add_parser('list', help='Lists all datasets')
+  new_parser.set_defaults(subparser_fn=_list_datasets)
+
+
+def _list_datasets(args: argparse.Namespace) -> None:
+  """Creates the dataset directory. Executed by `tfds new <name>`."""
+  list_datasets()
+
+
+def list_datasets():
+  datasets = load.list_builders(with_community_datasets=True)
+  for dataset in datasets:
+    print(dataset)

--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -9,11 +9,20 @@ from tensorflow_datasets.core import load
 def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: disable=protected-access
   """Add subparser for `list` command."""
   new_parser = parsers.add_parser('list', help='Lists all datasets')
+
+  new_parser.add_argument(
+    '--namespace',
+    type=str,
+    nargs='*',
+    dest='namespace_keyword',
+    help='Namespace flag for displaying datasets from given namespace'
+  )
+
   new_parser.set_defaults(subparser_fn=_list_datasets)
 
 
 def _list_datasets(args: argparse.Namespace) -> None:
-  """Creates the dataset directory. Executed by `tfds new <name>`."""
+  """Lists the datasets/namespaces. Executed by `tfds list <flags> <name>`."""
   list_datasets()
 
 

--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -29,10 +29,17 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: 
 
 def _list_datasets(args: argparse.Namespace) -> None:
   """Lists the datasets/namespaces. Executed by `tfds list <flags> <name>`."""
-  list_datasets()
-
+  if not args.namespace and not args.search_query:
+    list_datasets()
+  elif args.namespace:
+    list_namespace_datasets(namespace: args.namespace)
+  elif args.search_query:
+    search_datasets(search_query: args.search_query)
 
 def list_datasets():
   datasets = load.list_builders(with_community_datasets=True)
   for dataset in datasets:
     print(dataset)
+
+def list_namespace_datasets(namespace: str) -> None:
+  

--- a/tensorflow_datasets/scripts/cli/list.py
+++ b/tensorflow_datasets/scripts/cli/list.py
@@ -3,8 +3,9 @@
 
 import argparse
 
+from tensorflow_datasets.core import community
 from tensorflow_datasets.core import load
-
+from tensorflow_datasets.core import visibility
 
 def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: disable=protected-access
   """Add subparser for `list` command."""
@@ -13,7 +14,7 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:  # pylint: 
   new_parser.add_argument(
     '--namespace',
     type=str,
-    nargs='+',
+    nargs=1,
     help='Namespace flag for displaying datasets from given namespace'
   )
 
@@ -32,9 +33,9 @@ def _list_datasets(args: argparse.Namespace) -> None:
   if not args.namespace and not args.search_query:
     list_datasets()
   elif args.namespace:
-    list_namespace_datasets(namespace: args.namespace)
+    list_namespace_datasets(namespace=args.namespace)
   elif args.search_query:
-    search_datasets(search_query: args.search_query)
+    search_datasets(search_query=args.search_query)
 
 def list_datasets():
   datasets = load.list_builders(with_community_datasets=True)
@@ -42,4 +43,19 @@ def list_datasets():
     print(dataset)
 
 def list_namespace_datasets(namespace: str) -> None:
-  
+  datasets = list()
+  dataset_found = False
+  #Fetching all community datasets
+  if visibility.DatasetType.COMMUNITY_PUBLIC.is_available():
+    datasets = community.community_register.list_builders()
+
+  print(f"Datasets associated with `{namespace[0]}` namespace:")
+  #Getting all datasets for given namespace
+  for dataset in datasets:
+    if dataset.split(':')[0] == namespace[0]:
+      print(dataset)
+      if not dataset_found:
+        dataset_found = True
+
+  if not dataset_found:
+    print("No datasets match given namespace.")

--- a/tensorflow_datasets/scripts/cli/main.py
+++ b/tensorflow_datasets/scripts/cli/main.py
@@ -38,6 +38,7 @@ import tensorflow_datasets.public_api as tfds
 # Import commands
 from tensorflow_datasets.scripts.cli import build
 from tensorflow_datasets.scripts.cli import new
+from tensorflow_datasets.scripts.cli import list as list_
 
 FLAGS = flags.FLAGS
 
@@ -61,6 +62,7 @@ def _parse_flags(argv: List[str]) -> argparse.Namespace:
   subparser = parser.add_subparsers(title='command')
   build.register_subparser(subparser)
   new.register_subparser(subparser)
+  list_.register_subparser(subparser)
   return parser.parse_args(argv[1:])
 
 


### PR DESCRIPTION
In continuation to PR #3117 
Issue #3116 
The --namespace` and `--search` flags were added with support for multiple flags in CLI.
