### PR TITLE
Add necessary gtzan extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,7 @@ DATASET_EXTRAS = {
     'lsun': ['tensorflow-io'],
     'wsc273': ['bs4', 'lxml'],
     'youtube_vis': ['pycocotools'],
+    'gtzan': ['pydub'],
 }
 
 


### PR DESCRIPTION
Just a small tweak. `tfds.load("gtzan")` in a fresh Colab notebook complains that pydub is also needed (for the audio decoding).