### PR TITLE
Load metadata from metadata.json if there is any

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,11 +15,7 @@
             80
         ],
         "editor.tabSize": 2,
-        "editor.detectIndentation": false,
-        "editor.formatOnSave": false,
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": false
-        }
+        "editor.detectIndentation": false
     },
     "python.formatting.provider": "yapf",
     "python.testing.pytestArgs": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,11 @@
             80
         ],
         "editor.tabSize": 2,
-        "editor.detectIndentation": false
+        "editor.detectIndentation": false,
+        "editor.formatOnSave": false,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": false
+        }
     },
     "python.formatting.provider": "yapf",
     "python.testing.pytestArgs": [

--- a/tensorflow_datasets/core/dataset_info.py
+++ b/tensorflow_datasets/core/dataset_info.py
@@ -386,7 +386,9 @@ class DatasetInfo(object):
           dataset_info_dir
       )
     # Restore the MetaDataDict from metadata.json if there is any
-    if self.metadata or tf.io.gfile.exists(self._metadata_path(dataset_info_dir)):
+    if self.metadata or tf.io.gfile.exists(
+      self._metadata_path(dataset_info_dir)
+    ):
       # If the dataset was loaded from file, self.metadata will be `None`, so
       # we create a MetadataDict first.
       if not self.metadata:

--- a/tensorflow_datasets/core/dataset_info.py
+++ b/tensorflow_datasets/core/dataset_info.py
@@ -60,7 +60,6 @@ LICENSE_FILENAME = "LICENSE"
 METADATA_FILENAME = "metadata.json"
 
 
-
 # TODO(tfds): Do we require to warn the user about the peak memory used while
 # constructing the dataset?
 class DatasetInfo(object):
@@ -386,12 +385,12 @@ class DatasetInfo(object):
           dataset_info_dir
       )
     # Restore the MetaDataDict from metadata.json if there is any
-    if self.metadata or tf.io.gfile.exists(
+    if self.metadata is not None or tf.io.gfile.exists(
       self._metadata_path(dataset_info_dir)
     ):
       # If the dataset was loaded from file, self.metadata will be `None`, so
       # we create a MetadataDict first.
-      if not self.metadata:
+      if self.metadata is None:
         self._metadata = MetadataDict()
       self.metadata.load_metadata(dataset_info_dir)
 

--- a/tensorflow_datasets/core/dataset_info_test.py
+++ b/tensorflow_datasets/core/dataset_info_test.py
@@ -25,6 +25,7 @@ from tensorflow_datasets import testing
 from tensorflow_datasets.core import dataset_info
 from tensorflow_datasets.core import download
 from tensorflow_datasets.core import features
+from tensorflow_datasets.core import read_only_builder
 from tensorflow_datasets.core import utils
 from tensorflow_datasets.image_classification import mnist
 
@@ -339,6 +340,14 @@ feature {
       # Metadata should have been restored
       builder2 = RandomShapedImageGenerator(data_dir=tmp_dir)
       self.assertEqual(builder2.info.metadata, {"some_key": 123})
+
+      # Metadata should have been restored even if the builder code was not
+      # available and we restored from files.
+      builder3 = read_only_builder.builder_from_files(
+        builder.name,
+        data_dir=tmp_dir
+      )
+      self.assertEqual(builder3.info.metadata, {"some_key": 123})
 
   def test_updates_on_bucket_info(self):
 


### PR DESCRIPTION
Currently, specifying a dataset version in `tfds.load` will try to load the dataset from files using the `ReadOnlyBuilder` (see https://github.com/tensorflow/datasets/pull/2493). However, since it never specifies any metadata (see [`ReadOnlyBuilder._info`](https://github.com/tensorflow/datasets/blob/55f84b5723649a5bdedcce6b0343d8d0cb609140/tensorflow_datasets/core/read_only_builder.py#L101)), [the part of `DatasetInfo.read_from_directory` that is responsible for loading the metadata](https://github.com/tensorflow/datasets/blob/55f84b5723649a5bdedcce6b0343d8d0cb609140/tensorflow_datasets/core/dataset_info.py#L383) is never triggered, even though metadata might exist.

This PR creates a new `MetadataDict` if a `metadata.json` exist, and then loads the metadata from there. I've also added a unit test to verify that this behaviour previously did not work and now does. While that fixes the problem on my side, @Conchylicultor is there any reason why we use the builder code for loading the dataset at all (if no version is specified)? Since we can evidently load datasets from file just fine, and all the necessary information is present in the directory, why would we not always load from file if they exist? It seems to me that the builder should only be used for actually building a new version of the dataset.

Curious to hear your thoughts!