### PR TITLE
Remove supported versions for C4 dataset

### DIFF
--- a/tensorflow_datasets/text/c4.py
+++ b/tensorflow_datasets/text/c4.py
@@ -50,15 +50,6 @@ _CITATION = """
 """
 _VERSION = tfds.core.Version("3.0.1")
 
-# TODO(adarob): Remove supported versions. Starting with 3.0.0, all generated
-# datasets are automatically forward compatible. For example,
-# tfds.load('c4:3.0.0') works even if the code is at 3.0.1.
-_SUPPORTED_VERSIONS = [
-    tfds.core.Version("2.3.1"),
-    tfds.core.Version("2.3.0"),
-    tfds.core.Version("2.2.1"),
-    tfds.core.Version("2.2.0"),
-]
 RELEASE_NOTES = {
     "3.0.1": "Remove mC4 languages with less than 10k pages.",
     "3.0.0": "Add multilingual version (mC4). Deterministic URL deduplication.",
@@ -183,7 +174,6 @@ class C4Config(tfds.core.BuilderConfig):
     super(C4Config, self).__init__(
         name=name,
         version=_VERSION,
-        supported_versions=_SUPPORTED_VERSIONS,
         **kwargs)
 
     if clean and tuple(languages) != ("en",):


### PR DESCRIPTION
The `supported_versions` mentioned in the C4 dataset were too old to be generated with the current version of TFDS. So they were removed as mentioned in the `TODO`