### PR TITLE
Fix cars196 dataset URL

### DIFF
--- a/tensorflow_datasets/image_classification/cars196.py
+++ b/tensorflow_datasets/image_classification/cars196.py
@@ -19,7 +19,7 @@ import six.moves.urllib as urllib
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
-_URL = 'http://imagenet.stanford.edu/internal/car196/'
+_URL = 'http://ai.stanford.edu/~jkrause/car196/'
 _EXTRA_URL = 'https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz'
 
 _DESCRIPTION = (
@@ -148,10 +148,15 @@ _CITATION = """\
 class Cars196(tfds.core.GeneratorBasedBuilder):
   """Car Images dataset."""
 
-  VERSION = tfds.core.Version('2.0.0')
+  VERSION = tfds.core.Version('2.0.1')
   SUPPORTED_VERSIONS = [
       tfds.core.Version('2.1.0'),
   ]
+
+  RELEASE_NOTES = {
+      "2.0.0": "Initial release",
+      "2.0.1": "Website URL update",
+  }
 
   def _info(self):
     """Define the dataset info."""

--- a/tensorflow_datasets/url_checksums/cars196.txt
+++ b/tensorflow_datasets/url_checksums/cars196.txt
@@ -1,3 +1,6 @@
+http://ai.stanford.edu/~jkrause/car196/cars_test.tgz	977350468	bffea656d6f425cba3c91c6d83336e4c5f86c6cffd8975b0f375d3a10da8e243	cars_test.tgz
+http://ai.stanford.edu/~jkrause/car196/cars_test_annos_withlabels.mat	185758	790f75be8ea34eeded134cc559332baf23e30e91367e9ddca97d26ed9b895f05	cars_test_annos_withlabels.mat
+http://ai.stanford.edu/~jkrause/car196/cars_train.tgz	979269282	512b227b30e2f0a8aab9e09485786ab4479582073a144998da74d64b801fd288	cars_train.tgz
 http://imagenet.stanford.edu/internal/car196/cars_test.tgz	977350468	bffea656d6f425cba3c91c6d83336e4c5f86c6cffd8975b0f375d3a10da8e243	cars_test.tgz
 http://imagenet.stanford.edu/internal/car196/cars_test_annos_withlabels.mat	185758	790f75be8ea34eeded134cc559332baf23e30e91367e9ddca97d26ed9b895f05	cars_test_annos_withlabels.mat
 http://imagenet.stanford.edu/internal/car196/cars_train.tgz	979269282	512b227b30e2f0a8aab9e09485786ab4479582073a144998da74d64b801fd288	cars_train.tgz

--- a/tensorflow_datasets/url_checksums/cars196.txt
+++ b/tensorflow_datasets/url_checksums/cars196.txt
@@ -1,7 +1,4 @@
 http://ai.stanford.edu/~jkrause/car196/cars_test.tgz	977350468	bffea656d6f425cba3c91c6d83336e4c5f86c6cffd8975b0f375d3a10da8e243	cars_test.tgz
 http://ai.stanford.edu/~jkrause/car196/cars_test_annos_withlabels.mat	185758	790f75be8ea34eeded134cc559332baf23e30e91367e9ddca97d26ed9b895f05	cars_test_annos_withlabels.mat
 http://ai.stanford.edu/~jkrause/car196/cars_train.tgz	979269282	512b227b30e2f0a8aab9e09485786ab4479582073a144998da74d64b801fd288	cars_train.tgz
-http://imagenet.stanford.edu/internal/car196/cars_test.tgz	977350468	bffea656d6f425cba3c91c6d83336e4c5f86c6cffd8975b0f375d3a10da8e243	cars_test.tgz
-http://imagenet.stanford.edu/internal/car196/cars_test_annos_withlabels.mat	185758	790f75be8ea34eeded134cc559332baf23e30e91367e9ddca97d26ed9b895f05	cars_test_annos_withlabels.mat
-http://imagenet.stanford.edu/internal/car196/cars_train.tgz	979269282	512b227b30e2f0a8aab9e09485786ab4479582073a144998da74d64b801fd288	cars_train.tgz
 https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz	330960	b97deb463af7d58b6bfaa18b2a4de9829f0f79e8ce663dfa9261bf7810e9accd	car_devkit.tgz


### PR DESCRIPTION
Closes #3195, closes #3203, closes #3219
The train and test URL was changed and the URL checksums re-generated. The dataset is generated successfully now.