### PR TITLE
Fix grammar in error message

### DIFF
--- a/tensorflow_datasets/core/community/register_path.py
+++ b/tensorflow_datasets/core/community/register_path.py
@@ -113,7 +113,7 @@ class DataDirRegister(register_base.BaseRegister):
       close_matches = difflib.get_close_matches(
           name.namespace, self._ns2data_dir, n=1
       )
-      hint = f'\nDid you meant: {close_matches[0]}' if close_matches else ''
+      hint = f'\nDid you mean: {close_matches[0]}' if close_matches else ''
       raise KeyError(
           f'Namespace `{name.namespace}` for `{name}` not found. '
           f'Should be one of {sorted(self._ns2data_dir)}{hint}'

--- a/tensorflow_datasets/core/load.py
+++ b/tensorflow_datasets/core/load.py
@@ -452,6 +452,6 @@ def _reraise_with_list_builders(
   # Add close matches
   close_matches = difflib.get_close_matches(str(name), all_datasets, n=1)
   if close_matches:
-    error_string += f'\nDid you meant: {name} -> {close_matches[0]}\n'
+    error_string += f'\nDid you mean: {name} -> {close_matches[0]}\n'
 
   raise py_utils.reraise(e, suffix=error_string)


### PR DESCRIPTION
Fixed grammatical errors in hints from close matches.  "Mean" is correct in this case instead of "meant".