### PR TITLE
Repalce the 404 link in cars196.py with a working one

### DIFF
--- a/tensorflow_datasets/image_classification/cars196.py
+++ b/tensorflow_datasets/image_classification/cars196.py
@@ -19,7 +19,7 @@ import six.moves.urllib as urllib
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 
-_URL = 'http://imagenet.stanford.edu/internal/car196/'
+_URL = 'https://ai.stanford.edu/~jkrause/car196/'
 _EXTRA_URL = 'https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz'
 
 _DESCRIPTION = (


### PR DESCRIPTION
Replace the 404 URL with a working one.

Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follow the guidelines.

# Maintain an existing Dataset

* Dataset Name: cars196
* Issue Reference: N/A
* `dataset_info.json` Gist: N/A
  
## Description

The [original URL](https://image-net.org/internal/car196/) becomes 404 recently. I replace it with a working version that it can find `cars_train.tgz`, `cars_test.tgz`, and `cars_test_annos_withlabels.mat`.
 
