### PR TITLE
Add missing `person` builder config to LSUN dataset.

### DIFF
--- a/tensorflow_datasets/image/lsun.py
+++ b/tensorflow_datasets/image/lsun.py
@@ -75,6 +75,7 @@ _OBJECTS_CATEGORIES = [
     "dog",
     "horse",
     "motorbike",
+    "person",
     "potted_plant",
     "sheep",
     "sofa",
@@ -96,9 +97,10 @@ class Lsun(tfds.core.GeneratorBasedBuilder):
       tfds.core.BuilderConfig(  # pylint: disable=g-complex-comprehension
           name=category,
           description="Images of category %s" % category,
-          version=tfds.core.Version("3.0.0"),
+          version=tfds.core.Version("3.0.1"),
           release_notes={
               "3.0.0": "New split API (https://tensorflow.org/datasets/splits)",
+              "3.0.1": "Add builder config for missing `person` object category",
           },
       ) for category in (_SCENES_CATEGORIES + _OBJECTS_CATEGORIES)
   ]

--- a/tensorflow_datasets/image/lsun.py
+++ b/tensorflow_datasets/image/lsun.py
@@ -97,10 +97,10 @@ class Lsun(tfds.core.GeneratorBasedBuilder):
       tfds.core.BuilderConfig(  # pylint: disable=g-complex-comprehension
           name=category,
           description="Images of category %s" % category,
-          version=tfds.core.Version("3.0.1"),
+          version=tfds.core.Version("3.1.0"),
           release_notes={
               "3.0.0": "New split API (https://tensorflow.org/datasets/splits)",
-              "3.0.1": "Add builder config for missing `person` object category",
+              "3.1.0": "Add builder config for missing `person` object category, and add `id` to the feature dict",
           },
       ) for category in (_SCENES_CATEGORIES + _OBJECTS_CATEGORIES)
   ]
@@ -111,6 +111,7 @@ class Lsun(tfds.core.GeneratorBasedBuilder):
         description=("Large scale images showing different objects "
                      "from given categories like bedroom, tower etc."),
         features=tfds.features.FeaturesDict({
+            "id": tfds.features.Text(),
             "image": tfds.features.Image(encoding_format="jpeg"),
         }),
         homepage="https://www.yf.io/p/lsun",
@@ -156,6 +157,9 @@ class Lsun(tfds.core.GeneratorBasedBuilder):
     with tf.Graph().as_default():
       path = os.path.join(extracted_dir, file_path, "data.mdb")
       dataset = _make_lmdb_dataset(path)
-      for i, (_, jpeg_image) in enumerate(tfds.as_numpy(dataset)):
-        record = {"image": io.BytesIO(jpeg_image)}
+      for i, (id_bytes, jpeg_image) in enumerate(tfds.as_numpy(dataset)):
+        record = {
+          "id": id_bytes.decode("utf-8"),
+          "image": io.BytesIO(jpeg_image),
+        }
         yield i, record

--- a/tensorflow_datasets/url_checksums/lsun.txt
+++ b/tensorflow_datasets/url_checksums/lsun.txt
@@ -32,6 +32,7 @@ http://dl.yf.io/lsun/objects/dining_table.zip	51826252804	4c40a17884c7180a8f75a7
 http://dl.yf.io/lsun/objects/dog.zip	155606131278	dab08a84ce3facb2ac7261f58c1eea7f070a6d118b82f9778b6a1cf56ed15db4	dog.zip
 http://dl.yf.io/lsun/objects/horse.zip	73864289242	2ec7893f3308da7f68cc2bdb1e9a75cde7abf842628feea1c49c30006e9c3a1b	horse.zip
 http://dl.yf.io/lsun/objects/motorbike.zip	44948708338	76cba2c366269bf86ce57ff496a229b0a237d1095e4bddeec02c9c6b9aa1b9a3	motorbike.zip
+http://dl.yf.io/lsun/objects/person.zip	511754125920	4f6c58c308dfde383d77a018eed37a14e328cd7115b40396a38e15db68b00520	person.zip
 http://dl.yf.io/lsun/objects/potted_plant.zip	45844458500	98f723f17f256d7ad07018d19b4cb8d78ab17cedd994b49e5de366fec799d4d8	potted_plant.zip
 http://dl.yf.io/lsun/objects/sheep.zip	19063172058	549234a3cb2608adddea405c0918c64b143ee5636a7d6426a90ccc870f0928d0	sheep.zip
 http://dl.yf.io/lsun/objects/sofa.zip	60484209620	945c1a1a6106b57a47bda7287f223fcb95aa3fbd32fa7294d2a3741e4c143d95	sofa.zip


### PR DESCRIPTION
The LSUN dataset on TDFS includes all [10 available scene categories](http://dl.yf.io/lsun/scenes/) and 19 out of the [20 available object categories](http://dl.yf.io/lsun/objects/).

The missing object category is `person` - likely omitted because it is by far the largest.

This PR adds the person category, which makes the LSUN dataset complete.
