### PR TITLE
Add new `lsun/person` config to TFDS catalog

### DIFF
--- a/docs/catalog/lsun.md
+++ b/docs/catalog/lsun.md
@@ -30,6 +30,7 @@ tower etc.
 
 ```python
 FeaturesDict({
+    'id': Text(shape=(), dtype=tf.string),
     'image': Image(shape=(None, None, 3), dtype=tf.uint8),
 })
 ```
@@ -993,6 +994,32 @@ Split     | Examples
 Split     | Examples
 :-------- | --------:
 `'train'` | 1,194,101
+
+*   **Figure**
+    ([tfds.show_examples](https://www.tensorflow.org/datasets/api_docs/python/tfds/visualization/show_examples)):
+    Not supported.
+
+*   **Examples**
+    ([tfds.as_dataframe](https://www.tensorflow.org/datasets/api_docs/python/tfds/as_dataframe)):
+    Missing.
+
+## lsun/person
+
+*   **Config description**: Images of category person
+
+*   **Download size**: `476.61 GiB`
+
+*   **Dataset size**: `439.45 GiB`
+
+*   **Auto-cached**
+    ([documentation](https://www.tensorflow.org/datasets/performances#auto-caching)):
+    No
+
+*   **Splits**:
+
+Split     | Examples
+:-------- | --------:
+`'train'` | 18,890,816
 
 *   **Figure**
     ([tfds.show_examples](https://www.tensorflow.org/datasets/api_docs/python/tfds/visualization/show_examples)):


### PR DESCRIPTION
With the addition of `lsun/person` config in PR #3240, the documentation for adding the new config to the catalog as well as adding the id` feature has been done in this PR.

The download and dataset size as well as `num_examples` have been inferred from the `dataset_info.json` [here](https://gist.github.com/AdamHillier/5a5e9ccf9bc801a9de11ca5114efcb26)