### PR TITLE
Fix mistyped Opencv variable

### DIFF
--- a/tensorflow_datasets/image_classification/corruptions.py
+++ b/tensorflow_datasets/image_classification/corruptions.py
@@ -675,7 +675,7 @@ def spatter(x, severity=1):
     #     ker = np.array([[-1,-2,-3],[-2,0,0],[-3,0,1]], dtype=np.float32)
     #     ker -= np.mean(ker)
     ker = np.array([[-2, -1, 0], [-1, 1, 1], [0, 1, 2]])
-    dist = cv2.filter2D(dist, cv2.CVX_8U, ker)
+    dist = cv2.filter2D(dist, cv2.CV_8U, ker)
     dist = cv2.blur(dist, (3, 3)).astype(np.float32)
 
     m = cv2.cvtColor(liquid_layer * dist, cv2.COLOR_GRAY2BGRA)


### PR DESCRIPTION
The `cv2.CV_8U` was mistyped as `CVX_8U` due to which the `imagenet2012_corrupted/spatter` was not being generated for levels 1-3 as it utilizes the faulty variable. 

This PR fixes #3244 