### PR TITLE
Updated the url for the opinion-abstract dataset to a working one

### DIFF
--- a/tensorflow_datasets/summarization/opinion_abstracts.py
+++ b/tensorflow_datasets/summarization/opinion_abstracts.py
@@ -50,7 +50,7 @@ http://rottentomatoes.com/. It has fields of "_movie_name", "_movie_id",
 
 """
 
-_URL = "http://www.ccs.neu.edu/home/luwang/datasets/opinion_abstracts.zip"
+_URL = "https://web.eecs.umich.edu/~wangluxy/datasets/opinion_abstracts.zip"
 
 
 class OpinionAbstractsConfig(tfds.core.BuilderConfig):


### PR DESCRIPTION
The URL for the o_pinion_abstracts_ wasn't working and let to a `404`, so I found a new one on the [homepage](https://web.eecs.umich.edu/~wangluxy/data.html) of one the authors (Lu Wang).
