### PR TITLE
Upgrade the main code snippet on the TFDS index page

### DIFF
--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -24,14 +24,14 @@ landing_page:
         <a href="./catalog/overview#all_datasets">list of datasets</a>.
     - code_block: |
         <pre class = "prettyprint">
-        import tensorflow.compat.v2 as tf
+        import tensorflow as tf
         import tensorflow_datasets as tfds
 
         # Construct a tf.data.Dataset
         ds = tfds.load('mnist', split='train', shuffle_files=True)
 
         # Build your input pipeline
-        ds = ds.shuffle(1024).batch(32).prefetch(tf.data.experimental.AUTOTUNE)
+        ds = ds.shuffle(1024).batch(32).prefetch(tf.data.AUTOTUNE)
         for example in ds.take(1):
           image, label = example["image"], example["label"]
         </pre>


### PR DESCRIPTION
For TensorFlow 2: `import tensorflow as tf` <- `import tensorflow.compat.v2 as tf`
`AUTOTUNE` is out of experimental -> `ds = ds.shuffle(1024).batch(32).prefetch(tf.data.AUTOTUNE)`
cc @lamberta @MarkDaoust 

Related PR (for Colab): https://github.com/tensorflow/datasets/pull/3310 