### PR TITLE
Dataset generation (tfrecords) speedup

### DIFF
--- a/tensorflow_datasets/core/example_serializer.py
+++ b/tensorflow_datasets/core/example_serializer.py
@@ -118,7 +118,7 @@ def _is_string(item):
 def _item_to_np_array(item, dtype, shape):
   """Single item to a np.array."""
   original_item = item
-  item = np.array(item, dtype=dtype.as_numpy_dtype)
+  item = np.asanyarray(item, dtype=dtype.as_numpy_dtype)
   utils.assert_shape_match(item.shape, shape)
   if dtype == tf.string and not _is_string(original_item):
     raise ValueError(
@@ -134,13 +134,12 @@ def _item_to_tf_feature(item, tensor_info):
   if v.dtype == np.bool_:
     v = v.astype(int)
 
-  v = v.flatten()  # Convert v into a 1-d array
   if np.issubdtype(v.dtype, np.integer):
-    return tf.train.Feature(int64_list=tf.train.Int64List(value=v))
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=v.flat))
   elif np.issubdtype(v.dtype, np.floating):
-    return tf.train.Feature(float_list=tf.train.FloatList(value=v))
+    return tf.train.Feature(float_list=tf.train.FloatList(value=v.flat))
   elif tensor_info.dtype == tf.string:
-    v = [tf.compat.as_bytes(x) for x in v]
+    v = [tf.compat.as_bytes(x) for x in v.flat]
     return tf.train.Feature(bytes_list=tf.train.BytesList(value=v))
   else:
     raise ValueError(

--- a/tensorflow_datasets/core/utils/tf_utils.py
+++ b/tensorflow_datasets/core/utils/tf_utils.py
@@ -136,7 +136,7 @@ def is_dtype(value):
   return True
 
 
-@functools.lru_cache()
+@functools.cache
 def assert_shape_match(shape1, shape2):
   """Ensure the shape1 match the pattern given by shape2.
 

--- a/tensorflow_datasets/core/utils/tf_utils.py
+++ b/tensorflow_datasets/core/utils/tf_utils.py
@@ -17,6 +17,7 @@
 
 import collections
 import contextlib
+import functools
 from typing import Union
 
 import numpy as np
@@ -135,6 +136,7 @@ def is_dtype(value):
   return True
 
 
+@functools.lru_cache()
 def assert_shape_match(shape1, shape2):
   """Ensure the shape1 match the pattern given by shape2.
 

--- a/tensorflow_datasets/core/utils/tf_utils.py
+++ b/tensorflow_datasets/core/utils/tf_utils.py
@@ -136,7 +136,7 @@ def is_dtype(value):
   return True
 
 
-@functools.cache
+@functools.lru_cache
 def assert_shape_match(shape1, shape2):
   """Ensure the shape1 match the pattern given by shape2.
 


### PR DESCRIPTION
## Description
Some low-hanging fruits to fix #3357 
 
My tests show significant throughput improvement:
~100% on KDD 99 Cup 
~50% on Movielens
  
## Checklist
* [x] Address all TODO's
* [x] Add alphabetized import to subdirectory's `__init__.py`
* [x] Run `download_and_prepare` successfully
* [x] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [x] Properly cite in `BibTeX` format
* [x] Add passing test(s)
* [x] Add test data
* [x] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [x] Add data generation script (if applicable)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
