### PR TITLE
Updating faulty link in Food101.md document

### DIFF
--- a/docs/catalog/food101.md
+++ b/docs/catalog/food101.md
@@ -5,7 +5,7 @@
   <meta itemprop="name" content="food101" />
   <meta itemprop="description" content="This dataset consists of 101 food categories, with 101&#x27;000 images. For each class, 250 manually reviewed test images are provided as well as 750 training images. On purpose, the training images were not cleaned, and thus still contain some amount of noise. This comes mostly in the form of intense colors and sometimes wrong labels. All images were rescaled to have a maximum side length of 512 pixels.&#10;&#10;To use this dataset:&#10;&#10;```python&#10;import tensorflow_datasets as tfds&#10;&#10;ds = tfds.load(&#x27;food101&#x27;, split=&#x27;train&#x27;)&#10;for ex in ds.take(4):&#10;  print(ex)&#10;```&#10;&#10;See [the guide](https://www.tensorflow.org/datasets/overview) for more&#10;informations on [tensorflow_datasets](https://www.tensorflow.org/datasets).&#10;&#10;&lt;img src=&quot;https://storage.googleapis.com/tfds-data/visualization/fig/food101-2.0.0.png&quot; alt=&quot;Visualization&quot; width=&quot;500px&quot;&gt;&#10;&#10;" />
   <meta itemprop="url" content="https://www.tensorflow.org/datasets/catalog/food101" />
-  <meta itemprop="sameAs" content="https://www.vision.ee.ethz.ch/datasets_extra/food-101/" />
+  <meta itemprop="sameAs" content="https://data.vision.ee.ethz.ch/cvl/datasets_extra/food-101/" />
   <meta itemprop="citation" content="@inproceedings{bossard14,&#10;  title = {Food-101 -- Mining Discriminative Components with Random Forests},&#10;  author = {Bossard, Lukas and Guillaumin, Matthieu and Van Gool, Luc},&#10;  booktitle = {European Conference on Computer Vision},&#10;  year = {2014}&#10;}" />
 </div>
 


### PR DESCRIPTION
The homepage link to the Food101 paper given in the docs was wrong leading to a 404 error
Added the correct link to the Food101 paper


* Issue Reference: https://github.com/tensorflow/tensorflow/issues/51514

  
## Description

The link given for the Homepage of the Food-101 doesn't work
![image](https://user-images.githubusercontent.com/43718923/129580348-134cfd33-b9de-4654-9100-ee41892487a5.png)

It leads to a 404 Page not found eoor
![image](https://user-images.githubusercontent.com/43718923/129580397-af0cda54-4baa-498e-8d37-092d6b49abed.png)

Added the correct link to the Food101 paper

Correct link to the paper: https://data.vision.ee.ethz.ch/cvl/datasets_extra/food-101/


  

