### PR TITLE
Updating faulty link in food101.py file

### DIFF
--- a/tensorflow_datasets/image_classification/food101.py
+++ b/tensorflow_datasets/image_classification/food101.py
@@ -69,7 +69,7 @@ class Food101(tfds.core.GeneratorBasedBuilder):
         description=(_DESCRIPTION),
         features=tfds.features.FeaturesDict(features_dict),
         supervised_keys=("image", "label"),
-        homepage="https://www.vision.ee.ethz.ch/datasets_extra/food-101/",
+        homepage="https://data.vision.ee.ethz.ch/cvl/datasets_extra/food-101/",
         citation=_CITATION)
 
   def _split_generators(self, dl_manager):


### PR DESCRIPTION
The homepage link to the Food101 paper given in the docs was wrong leading to a 404 error
Added the correct link to the Food101 paper


The link given for the Homepage of the Food-101 doesn't work
Link to docs: https://www.tensorflow.org/datasets/catalog/food101

![image](https://user-images.githubusercontent.com/43718923/129703584-b91c47a7-1536-400a-bf58-46a55371b6ca.png)


It leads to a 404 Page not found eoor

![image](https://user-images.githubusercontent.com/43718923/129703635-77608d7a-b1ec-4165-89b5-12f5c2d37cf1.png)


Added the correct link to the Food101 paper

Correct link to the paper: https://data.vision.ee.ethz.ch/cvl/datasets_extra/food-101/
