### PR TITLE
Update AI2_ARC dataset url to new bucket

### DIFF
--- a/tensorflow_datasets/question_answering/ai2_arc.py
+++ b/tensorflow_datasets/question_answering/ai2_arc.py
@@ -43,7 +43,7 @@ We pose ARC as a challenge to the community.
 """
 
 _HOMEPAGE = "https://allenai.org/data/arc"
-_URL = "https://ai2-datasets.s3-us-west-2.amazonaws.com/arc/ARC-V1-Feb2018.zip"
+_URL = "https://ai2-public-datasets.s3-us-west-2.amazonaws.com/arc/ARC-V1-Feb2018.zip"
 
 
 class Ai2ArcConfig(tfds.core.BuilderConfig):

--- a/tensorflow_datasets/url_checksums/ai2_arc.txt
+++ b/tensorflow_datasets/url_checksums/ai2_arc.txt
@@ -1,1 +1,1 @@
-https://ai2-datasets.s3-us-west-2.amazonaws.com/arc/ARC-V1-Feb2018.zip	680841265	6d2d5ab50b2ceec6ba5f79c921be77cf2de712ea25a2b3f4fff3acc101cecfa0	ARC-V1-Feb2018.zip
+https://ai2-public-datasets.s3-us-west-2.amazonaws.com/arc/ARC-V1-Feb2018.zip	680841265	6d2d5ab50b2ceec6ba5f79c921be77cf2de712ea25a2b3f4fff3acc101cecfa0	ARC-V1-Feb2018.zip


### PR DESCRIPTION
# Update AI2_ARC Dataset

* Dataset Name: ai2_arc
* Issue Reference: https://github.com/tensorflow/datasets/issues/3452
  
## Description

As detailed in https://github.com/tensorflow/datasets/issues/3452, the AI2 dataset appears to have moved to a new bucket. I have updated the dataset config to reflect this. I'm not 100% sure this is all that needs to happen, however `tfds build ai2_arc` works off this package. Let me know if I've missed anything!
  
## Checklist
* [x] Address all TODO's
* [x] Add alphabetized import to subdirectory's `__init__.py`
* [x] Run `download_and_prepare` successfully
* [x] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [x] Properly cite in `BibTeX` format
* [x] Add passing test(s)
* [x] Add test data
* [x] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [x] Add data generation script (if applicable)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
