### PR TITLE
Add pass dataset

### DIFF
--- a/tensorflow_datasets/image/__init__.py
+++ b/tensorflow_datasets/image/__init__.py
@@ -101,5 +101,6 @@ from tensorflow_datasets.image_classification.sun import Sun397
 from tensorflow_datasets.image_classification.svhn import SvhnCropped
 from tensorflow_datasets.image_classification.uc_merced import UcMerced
 from tensorflow_datasets.image_classification.visual_domain_decathlon import VisualDomainDecathlon
+from tensorflow_datasets.image_classification.pass_dataset import PASS
 
 # Legacy aliases

--- a/tensorflow_datasets/image/__init__.py
+++ b/tensorflow_datasets/image/__init__.py
@@ -84,6 +84,7 @@ from tensorflow_datasets.image_classification.mnist_corrupted import MNISTCorrup
 from tensorflow_datasets.image_classification.omniglot import Omniglot
 from tensorflow_datasets.image_classification.oxford_flowers102 import OxfordFlowers102
 from tensorflow_datasets.image_classification.oxford_iiit_pet import OxfordIIITPet
+from tensorflow_datasets.image_classification.pass_dataset import PASS
 from tensorflow_datasets.image_classification.patch_camelyon import PatchCamelyon
 from tensorflow_datasets.image_classification.pet_finder import PetFinder
 from tensorflow_datasets.image_classification.places365_small import Places365Small
@@ -101,6 +102,6 @@ from tensorflow_datasets.image_classification.sun import Sun397
 from tensorflow_datasets.image_classification.svhn import SvhnCropped
 from tensorflow_datasets.image_classification.uc_merced import UcMerced
 from tensorflow_datasets.image_classification.visual_domain_decathlon import VisualDomainDecathlon
-from tensorflow_datasets.image_classification.pass_dataset import PASS
+
 
 # Legacy aliases

--- a/tensorflow_datasets/image/pass_dataset/pass_dataset.py
+++ b/tensorflow_datasets/image/pass_dataset/pass_dataset.py
@@ -1,0 +1,60 @@
+"""PASS dataset."""
+
+import tensorflow_datasets as tfds
+import urllib.request
+
+_DESCRIPTION = """
+PASS is a large-scale image dataset that does not include any humans,
+human parts, or other personally identifiable information.
+It that can be used for high-quality self-supervised pretraining while significantly reducing privacy concerns.
+
+PASS contains 1.440.191 images without any labels sourced from YFCC-100M.
+"""
+
+_CITATION = """
+@Article{asano21pass,
+author = "Yuki M. Asano and Christian Rupprecht and Andrew Zisserman and Andrea Vedaldi",
+title = "PASS: An ImageNet replacement for self-supervised pretraining without humans",
+journal = "NeurIPS Track on Datasets and Benchmarks",
+year = "2021"
+}
+"""
+
+
+class PASS(tfds.core.GeneratorBasedBuilder):
+  """DatasetBuilder for pass dataset."""
+
+  VERSION = tfds.core.Version('1.0.0')
+  RELEASE_NOTES = {
+      '1.0.0': 'Initial release.',
+  }
+
+  def _info(self) -> tfds.core.DatasetInfo:
+    """Returns the dataset metadata."""
+    return tfds.core.DatasetInfo(
+        builder=self,
+        description=_DESCRIPTION,
+        features=tfds.features.FeaturesDict({
+            'image': tfds.features.Image(shape=(None, None, 3)),
+        }),
+        supervised_keys=None,
+        homepage='https://www.robots.ox.ac.uk/~vgg/research/pass/',
+        citation=_CITATION,
+    )
+
+  def _split_generators(self, dl_manager: tfds.download.DownloadManager):
+    """Returns SplitGenerators."""
+    urls =  urllib.request.urlopen("https://www.robots.ox.ac.uk/~vgg/research/pass/pass_urls.txt")
+    urls = [li.decode("utf-8").split('\n')[0] for li in urls]
+    path = dl_manager.download(urls)
+
+    return {
+        'train': self._generate_examples(path),
+    }
+
+  def _generate_examples(self, path):
+    """Yields examples."""
+    for idx,f in enumerate(path):
+      yield idx, {
+          'image': f,
+      }


### PR DESCRIPTION
# Add Dataset

* Dataset Name: PASS: An ImageNet replacement for self-supervised pretraining without humans
* `dataset_info.json` Gist: <link>

## Description
The dataset is an image dataset containing 1.4M images that are sourced from YFCC-100M and solely contain CC-BY images without any humans or other personally identifiable information.
The paper has been accepted to the NeurIPS Datasets conference:

https://openreview.net/forum?id=BwzYI-KaHdr

Note: One thing that would speed up the dataset download is to use the 10 tar files (instead of the current list of urls of images) stored at https://zenodo.org/record/5501843, but I am not sure how to download and then merge the .tar files before extracting them. 

## Checklist
* [X] Add alphabetized import to subdirectory's `__init__.py`
* [X] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [X] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [X] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [X] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
