### PR TITLE
Fix small typo in guide to splitting data

### DIFF
--- a/docs/splits.md
+++ b/docs/splits.md
@@ -45,7 +45,7 @@ Split can be:
 
 ```python
 # Returns both train and test split separately
-train_ds, test_ds = tfds.load('mnist', split=['train', 'test[50%]'])
+train_ds, test_ds = tfds.load('mnist', split=['train', 'test[:50%]'])
 ```
 
 Note: Due to the shards being


### PR DESCRIPTION
I've just found a small typo in the documentation that might be confusing to other tensorflow beginners like me.

In the <a href="https://www.tensorflow.org/datasets/splits"> splits guide </a>, there is a line of code that explains how to load a dataset into testing and training data with a 50% split.

```python
# Returns both train and test split separately
train_ds, test_ds = tfds.load('mnist', split=['train', 'test[50%]'])
```

But this code doesn't run.  It should be 'test[:50%]'.

```python
# Returns both train and test split separately
train_ds, test_ds = tfds.load('mnist', split=['train', 'test[:50%]'])
```

This works.