### PR TITLE
Remove usage of deprecated `distutils.version` module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ REQUIRED_PKGS = [
     'etils[epath-no-tf]',
     'numpy',
     'promise',
+    'packaging>=14.1',
     'protobuf>=3.12.2',
     'requests>=2.19.0',
     'six',

--- a/tensorflow_datasets/core/tf_compat.py
+++ b/tensorflow_datasets/core/tf_compat.py
@@ -17,9 +17,9 @@
 
 # pylint: disable=g-import-not-at-top,g-direct-tensorflow-import
 
-import distutils.version
 import functools
 import os
+import packaging.version
 from typing import Optional
 
 MIN_TF_VERSION = "2.1.0"
@@ -56,8 +56,8 @@ def ensure_tf_install():  # pylint: disable=g-statement-before-imports
     print("***************************************************************\n\n")
     raise
 
-  tf_version = distutils.version.LooseVersion(tf.__version__)
-  min_tf_version = distutils.version.LooseVersion(MIN_TF_VERSION)
+  tf_version = packaging.version.parse(tf.__version__)
+  min_tf_version = packaging.version.parse(MIN_TF_VERSION)
   if tf_version < min_tf_version:
     raise ImportError(
         "This version of TensorFlow Datasets requires TensorFlow "


### PR DESCRIPTION
`distutils` has been deprecated in https://peps.python.org/pep-0632/ and will be completely removed in 3.12.

`distutils.version.LooseVersion` already started throwing deprecation warnings in Python 3.9 so this PR replaces its usage with [`packaging.version.parse`](https://peps.python.org/pep-0632/#migration-advice) as the recommended replacement.

Technically this adds `packaging` as a new direct dependency, but in practice this doesn't matter since it will likely be already installed as an indirect dependency anyway.