### PR TITLE
Fixes path in librispeech.py

### DIFF
--- a/tensorflow_datasets/audio/librispeech.py
+++ b/tensorflow_datasets/audio/librispeech.py
@@ -120,7 +120,7 @@ def _generate_librispeech_examples(directory):
   transcripts_glob = os.path.join(directory, "LibriSpeech", "*/*/*/*.txt")
   for transcript_file in tf.io.gfile.glob(transcripts_glob):
     path = os.path.dirname(transcript_file)
-    with tf.io.gfile.GFile(os.path.join(path, transcript_file)) as f:
+    with tf.io.gfile.GFile(transcript_file) as f:
       for line in f:
         line = line.strip()
         key, transcript = line.split(" ", 1)


### PR DESCRIPTION
This PR fixes the `Not a single example present in the PCollection!` assertion error while running `tfds build librispeech`.

The fix came from https://github.com/tensorflow/datasets/pull/2181/files.