### PR TITLE
Fix for bug 2889 - Loading SUN397 crashed.

### DIFF
--- a/tensorflow_datasets/image_classification/sun.py
+++ b/tensorflow_datasets/image_classification/sun.py
@@ -58,6 +58,7 @@ _SUN397_URL = "https://vision.princeton.edu/projects/2010/SUN/"
 # decoding is not deterministic (PIL).
 _SUN397_IGNORE_IMAGES = [
     "SUN397/c/church/outdoor/sun_bhenjvsvrtumjuri.jpg",
+    "SUN397/t/track/outdoor/sun_aophkoiosslinihb.jpg",
 ]
 
 _SUN397_BUILDER_CONFIG_DESCRIPTION_PATTERN = (
@@ -281,6 +282,8 @@ class Sun397(tfds.core.GeneratorBasedBuilder):
     with tf.Graph().as_default():
       with utils.nogpu_session() as sess:
         for filepath, fobj in archive:
+          if filepath in _SUN397_IGNORE_IMAGES:
+            continue
           # Note: all files in the tar.gz are in SUN397/...
           filename = filepath[prefix_len:].replace("\\", "/")  # For windows
           if filename in subset_images:


### PR DESCRIPTION
Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Fixed issue 2889 - Loading SUN397 crashed

* Dataset Name: sun397
* Issue Reference: [Issue 2889](https://github.com/tensorflow/datasets/issues/2889)

## Description
A very small, surgical fix that allows the sun397 dataset to be downloaded and  installed without issue. I made two small changes:
* I added a file that could not be decoded to the pre-existing ```_SUN397_IGNORE_IMAGES``` list.
* Even though the list ```_SUN397_IGNORE_IMAGES``` was present in the code, it was never referred to. So all I did was add an ```if``` statement in the main decoding loop that would ignore any file in the ```_SUN397_IGNORE_IMAGES``` list.

## Checklist

* [x] Run `download_and_prepare` successfully
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
