### PR TITLE
feat(downloader): allow additional request arguments per resource

### DIFF
--- a/tensorflow_datasets/core/download/download_manager.py
+++ b/tensorflow_datasets/core/download/download_manager.py
@@ -356,7 +356,7 @@ class DownloadManager(object):
       download_tmp_dir.mkdir()
       logging.info(f'Downloading {url} into {download_tmp_dir}...')
       future = self._downloader.download(
-          url, download_tmp_dir, verify=self._verify_ssl)
+          url, download_tmp_dir, verify=self._verify_ssl, **resource.request_kwargs)
 
     # Post-process the result
     return future.then(lambda dl_result: self._register_or_validate_checksums(  # pylint: disable=g-long-lambda

--- a/tensorflow_datasets/core/download/downloader.py
+++ b/tensorflow_datasets/core/download/downloader.py
@@ -148,7 +148,8 @@ class _Downloader(object):
       self,
       url: str,
       destination_path: str,
-      verify: bool = True
+      verify: bool = True,
+      **request_kwargs
   ) -> 'promise.Promise[concurrent.futures.Future[DownloadResult]]':
     """Download url to given path.
 
@@ -158,6 +159,7 @@ class _Downloader(object):
       url: address of resource to download.
       destination_path: `str`, path to directory where to download the resource.
       verify: whether to verify ssl certificates
+      **request_kwargs: Additional kwargs to forward to `request.get`.
 
     Returns:
       Promise obj -> (`str`, int): (downloaded object checksum, size in bytes).
@@ -165,7 +167,7 @@ class _Downloader(object):
     destination_path = os.fspath(destination_path)
     self._pbar_url.update_total(1)
     future = self._executor.submit(self._sync_download, url, destination_path,
-                                   verify)
+                                   verify, **request_kwargs)
     return promise.Promise.resolve(future)
 
   def _sync_file_copy(
@@ -187,7 +189,8 @@ class _Downloader(object):
   def _sync_download(self,
                      url: str,
                      destination_path: str,
-                     verify: bool = True) -> DownloadResult:
+                     verify: bool = True,
+                     **request_kwargs) -> DownloadResult:
     """Synchronous version of `download` method.
 
     To download through a proxy, the `HTTP_PROXY`, `HTTPS_PROXY`,
@@ -199,6 +202,7 @@ class _Downloader(object):
       url: url to download
       destination_path: path where to write it
       verify: whether to verify ssl certificates
+      **request_kwargs: Additional kwargs to forward to `request.get`.
 
     Returns:
       None
@@ -214,7 +218,7 @@ class _Downloader(object):
     except tf.errors.UnimplementedError:
       pass
 
-    with _open_url(url, verify=verify) as (response, iter_content):
+    with _open_url(url, verify=verify, **request_kwargs) as (response, iter_content):
       fname = _get_filename(response)
       path = os.path.join(destination_path, fname)
       size = 0

--- a/tensorflow_datasets/core/download/resource.py
+++ b/tensorflow_datasets/core/download/resource.py
@@ -301,6 +301,7 @@ class Resource(object):
         set, will be guessed from downloaded file name `original_fname`.
       path: `str`, path of resource on local disk. Can be None if resource has
         not be downloaded yet. In such case, `url` must be set.
+      **request_kwargs: Additional kwargs to forward to `request.get`.
     """
     self.url = url
     self.path: epath.Path = epath.Path(path) if path else None  # pytype: disable=annotation-type-mismatch  # attribute-variable-annotations

--- a/tensorflow_datasets/core/download/resource.py
+++ b/tensorflow_datasets/core/download/resource.py
@@ -291,6 +291,7 @@ class Resource(object):
       url: Optional[str] = None,
       extract_method: Optional[ExtractMethod] = None,
       path: Optional[epath.PathLike] = None,
+      **request_kwargs
   ):
     """Resource constructor.
 
@@ -304,6 +305,7 @@ class Resource(object):
     self.url = url
     self.path: epath.Path = epath.Path(path) if path else None  # pytype: disable=annotation-type-mismatch  # attribute-variable-annotations
     self._extract_method = extract_method
+    self.request_kwargs = request_kwargs
 
   @classmethod
   def exists_locally(cls, path: epath.PathLike):


### PR DESCRIPTION
Partially addresses https://github.com/tensorflow/datasets/issues/2960

There are a few datasets that require authentication (user-password `basic` auth), or additional headers to download, or just cookies, and creating custom downloaders for each is a pain.

This PR suggests the following case:

#### `basic` auth
```py
dl_manager.download(tfds.download.Resource(url, auth=(username, password)))
```

#### cookies
```py
cookies = {'cookies_are': 'yummy'}
dl_manager.download(tfds.download.Resource(url, cookies=cookies))
```