### PR TITLE
dict comprehension is faster than using dict constructor

### DIFF
--- a/tensorflow_datasets/image/s3o4d/s3o4d.py
+++ b/tensorflow_datasets/image/s3o4d/s3o4d.py
@@ -89,20 +89,19 @@ class S3o4d(tfds.core.GeneratorBasedBuilder):
     suffices = {'img': 'images.zip', 'latent': 'latents.npz'}
     prod = itertools.product(['bunny', 'dragon'], ['train', 'test'],
                              ['img', 'latent'])
-    path_dict = dict([
-        ('_'.join([a, b, c]),
-         f'https://storage.googleapis.com/dm_s3o4d/{a}/{b}_{suffices[c]}')
+    path_dict = {
+        '_'.join([a, b, c]): f'https://storage.googleapis.com/dm_s3o4d/{a}/{b}_{suffices[c]}'
         for a, b, c in prod
-    ])
+    }
     paths = dl_manager.download(path_dict)
 
-    return dict([
-        (  # pylint: disable=g-complex-comprehension
-            '_'.join([a, b]),
-            self._generate_examples(dl_manager, paths['_'.join([a, b, 'img'])],
-                                    paths['_'.join([a, b, 'latent'])], a))
+    return {
+        # pylint: disable=g-complex-comprehension
+        '_'.join([a, b]):
+        self._generate_examples(dl_manager, paths['_'.join([a, b, 'img'])],
+                                paths['_'.join([a, b, 'latent'])], a)
         for a, b in itertools.product(['bunny', 'dragon'], ['train', 'test'])
-    ])
+    }
 
   def _generate_examples(self, dl_manager: tfds.download.DownloadManager,
                          img_path, latent_path, label):

--- a/tensorflow_datasets/image_classification/imagenet2012_multilabel/imagenet2012_multilabel.py
+++ b/tensorflow_datasets/image_classification/imagenet2012_multilabel/imagenet2012_multilabel.py
@@ -260,8 +260,7 @@ class Imagenet2012Multilabel(tfds.core.GeneratorBasedBuilder):
     (multi_labels, problematic_images, imagenet_m_2022_errors
     ) = _get_multi_labels_and_problematic_images(dl_manager)
 
-    imagenet_m_2022 = dict([(k, multi_labels[k]) for k in imagenet_m_2022_errors
-                           ])
+    imagenet_m_2022 = {k: multi_labels[k] for k in imagenet_m_2022_errors}
 
     return {
         'validation':

--- a/tensorflow_datasets/text/wsc273/wsc273.py
+++ b/tensorflow_datasets/text/wsc273/wsc273.py
@@ -99,7 +99,7 @@ def normalize_cap(option, pron):
   cap_tuples = [("The", "the"), ("His", "his"), ("My", "my"), ("Her", "her"),
                 ("Their", "their"), ("An", "an"), ("A", "a")]
   uncap_dict = dict(cap_tuples)
-  cap_dict = dict([(t[1], t[0]) for t in cap_tuples])
+  cap_dict = {t[1]: t[0] for t in cap_tuples}
   words = option.split(" ")
   first_word = words[0]
   if pron[0].islower():


### PR DESCRIPTION
## Description

Replace `dict` constructor with `dict` comprehension which is faster. 

## Checklist

* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
