### PR TITLE
Update wikipedia.py data storage link

### DIFF
--- a/tensorflow_datasets/text/wikipedia.py
+++ b/tensorflow_datasets/text/wikipedia.py
@@ -85,7 +85,7 @@ WIKIPEDIA_LANGUAGES = [
 ]
 
 # Use mirror (your.org) to avoid download caps.
-_BASE_URL_TMPL = "https://dumps.wikimedia.your.org/{lang}wiki/{date}/"
+_BASE_URL_TMPL = "https://dumps.wikimedia.your.org/pub/wikimedia/dumps/{lang}wiki/{date}/"
 _INFO_FILE = "dumpstatus.json"
 
 


### PR DESCRIPTION


## Description
link not found with the following code

```
import tensorflow_datasets as tfds
ds = tfds.load('wikipedia/20220620.zh', split='train')
```
The new header for wikipedia seems to be under ```https://dumps.wikimedia.your.org/pub/wikimedia/dumps```
After changing to this link I was able to download the data.
