### PR TITLE
Fix a command-line snippet on GCS documentation.

### DIFF
--- a/docs/gcs.md
+++ b/docs/gcs.md
@@ -44,7 +44,7 @@ If you run on your local machine (or in VM), you can authenticate with your
 account by running:
 
 ```shell
-gcloud login application-default
+gcloud auth login application-default
 ```
 
 If you want to login with service account, download the JSON file key and set


### PR DESCRIPTION
There's an issue in "gcs.md" on the command-line arguments of "gcloud".
I think the PR checklist is not applicable for this kind of small doc fix.

I'm not an expert of Google Cloud SDK, but I confirmed it worked with the fix.