### PR TITLE
Add valid_tags.txt to PyPI releases.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,6 +228,7 @@ setup(
                 # Bundle `datasets/` folder in PyPI releases
                 'datasets/*/*',
                 'core/utils/colormap.csv',
+                'core/valid_tags.txt',
                 'scripts/documentation/templates/*',
                 'url_checksums/*',
                 'checksums.tsv',


### PR DESCRIPTION
Without this file any custom dataset test will fail since 23e77add4a3c8d2cd86575678f8f991f7a571701. This commit added the `test_valid_tags` and `test_valid_tags_with_comments` tests which require this file.
