### PR TITLE
Update overview.ipynb

### DIFF
--- a/docs/overview.ipynb
+++ b/docs/overview.ipynb
@@ -675,7 +675,7 @@
         "\n",
         "To find out which urls to download, look into:\n",
         "\n",
-        " * For new datasets (implemented as folder): [`tensorflow_datasets/`](https://github.com/tensorflow/datasets/tree/master/tensorflow_datasets/)`\u003ctype\u003e/\u003cdataset_name\u003e/checksums.tsv`. For example: [`tensorflow_datasets/text/bool_q/checksums.tsv`](https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/text/bool_q/checksums.tsv).\n",
+        " * For new datasets (implemented as folder): [`tensorflow_datasets/`](https://github.com/tensorflow/datasets/tree/master/tensorflow_datasets/)`\u003ctype\u003e/\u003cdataset_name\u003e/checksums.tsv`. For example: [`tensorflow_datasets/datasets/bool_q/checksums.tsv`](https://github.com/tensorflow/datasets/blob/master/tensorflow_datasets/datasets/bool_q/checksums.tsv).\n",
         "\n",
         "   You can find the dataset source location in [our catalog](https://www.tensorflow.org/datasets/catalog/overview).\n",
         " * For old datasets: [`tensorflow_datasets/url_checksums/\u003cdataset_name\u003e.txt`](https://github.com/tensorflow/datasets/tree/master/tensorflow_datasets/url_checksums)\n",


### PR DESCRIPTION
Changed example from "tensorflow_datasets/text/bool_q/checksums.tsv" to "tensorflow_datasets/datasets/bool_q/checksums.tsv" and fixed the broken link to the same in line 678.

