### PR TITLE
Support logging in the Hugging Face wrapper

### DIFF
--- a/tensorflow_datasets/core/community/huggingface_wrapper.py
+++ b/tensorflow_datasets/core/community/huggingface_wrapper.py
@@ -21,6 +21,7 @@ import builtins
 import contextlib
 import functools
 import glob
+import logging
 import os
 import sys
 import types
@@ -274,6 +275,19 @@ class _MockedHFDatasets(types.ModuleType):
       input: str
       output: str
 
+  class utils(types.ModuleType):
+    """`datasets.utils` module."""
+
+    class logging(types.ModuleType):
+      """`datasets.utils.logging` module."""
+
+      @staticmethod
+      def get_logger(name: Optional[str] = None) -> logging.Logger:
+        """Returns a `Logger` with the supplied name."""
+        if name is None:
+          name, _ = __name__.split('.', maxsplit=1)
+        return logging.getLogger(name)
+
   # pylint: enable=invalid-name
 
 
@@ -282,6 +296,12 @@ for attr in dir(_MockedHFDatasets.features):
   if attr.startswith('_'):
     continue
   setattr(_MockedHFDatasets, attr, getattr(_MockedHFDatasets.features, attr))
+
+# `datasets.utils.Xyz` API can also be accessed as `datasets.Xyz`
+for attr in dir(_MockedHFDatasets.utils):
+  if attr.startswith('_'):
+    continue
+  setattr(_MockedHFDatasets, attr, getattr(_MockedHFDatasets.utils, attr))
 
 # Mock the standard file API to use GFile
 

--- a/tensorflow_datasets/testing/huggingface/dummy_dataset.py
+++ b/tensorflow_datasets/testing/huggingface/dummy_dataset.py
@@ -20,6 +20,8 @@ from pathlib import Path  # < Direct import of path should be patched  # pylint:
 import datasets  # pytype: disable=import-error
 import tensorflow_datasets.public_api as tfds
 
+logger = datasets.logging.get_logger(__name__)
+
 
 class HFDataset(datasets.GeneratorBasedBuilder):
   """AdversarialQA. Version 1.0.0."""
@@ -74,6 +76,8 @@ class HFDataset(datasets.GeneratorBasedBuilder):
 
   def _generate_examples(self, num_vals):
     """This function returns the examples in the raw (text) form."""
+    logger.info("some text")
+
     # Path is mocked
     assert isinstance(Path("some_path/"), tfds.core.Path)  # pylint: disable=protected-access
     for i in range(num_vals):


### PR DESCRIPTION
This pull request resolves #3712. 

Many Hugging Face datasets builders call [`datasets.logging.get_logger`](https://github.com/huggingface/datasets/blob/2.5.2/src/datasets/utils/logging.py#L78) [1], which is not implemented in `huggingface_wrapper.py`. Consequently, this prevents such dataset builders from being used with TensorFlow Datasets. This pull request updates the Hugging Face wrapper to support logging.

<details>
<summary>[1]: As of Hugging Face datasets version 2.5.2, over 100 datasets call the logging API.</summary>
<pre>
$ grep -rl . -e "datasets.logging.get_logger(__name__)" | sort 
./adversarial_qa/adversarial_qa.py
./afrikaans_ner_corpus/afrikaans_ner_corpus.py
./ami/ami.py
./amttl/amttl.py
./arcd/arcd.py
./bc2gm_corpus/bc2gm_corpus.py
./bigbench/bigbench.py
./biomrc/biomrc.py
./blog_authorship_corpus/blog_authorship_corpus.py
./c4/c4.py
./cats_vs_dogs/cats_vs_dogs.py
./cc_news/cc_news.py
./cfq/cfq.py
./cnn_dailymail/cnn_dailymail.py
./conll2000/conll2000.py
./conll2002/conll2002.py
./conll2003/conll2003.py
./consumer-finance-complaints/consumer-finance-complaints.py
./covid_qa_castorini/covid_qa_castorini.py
./covid_qa_deepset/covid_qa_deepset.py
./crd3/crd3.py
./doc2dial/doc2dial.py
./dream/dream.py
./eli5/eli5.py
./eli5_category/eli5_category.py
./elkarhizketak/elkarhizketak.py
./ethos/ethos.py
./euronews/euronews.py
./europa_ecdc_tm/europa_ecdc_tm.py
./finer/finer.py
./germeval_14/germeval_14.py
./grail_qa/grail_qa.py
./harem/harem.py
./hausa_voa_ner/hausa_voa_ner.py
./id_clickbait/id_clickbait.py
./id_liputan6/id_liputan6.py
./id_nergrit_corpus/id_nergrit_corpus.py
./id_newspapers_2018/id_newspapers_2018.py
./id_panl_bppt/id_panl_bppt.py
./interpress_news_category_tr/interpress_news_category_tr.py
./interpress_news_category_tr_lite/interpress_news_category_tr_lite.py
./isixhosa_ner_corpus/isixhosa_ner_corpus.py
./isizulu_ner_corpus/isizulu_ner_corpus.py
./jnlpba/jnlpba.py
./kilt_tasks/kilt_tasks.py
./kilt_wikipedia/kilt_wikipedia.py
./kor_ner/kor_ner.py
./lener_br/lener_br.py
./linnaeus/linnaeus.py
./lm1b/lm1b.py
./mac_morpho/mac_morpho.py
./masakhaner/masakhaner.py
./math_dataset/math_dataset.py
./mc4/mc4.py
./medal/medal.py
./mocha/mocha.py
./msra_ner/msra_ner.py
./multidoc2dial/multidoc2dial.py
./ncbi_disease/ncbi_disease.py
./nlu_evaluation_data/nlu_evaluation_data.py
./offenseval2020_tr/offenseval2020_tr.py
./onestop_english/onestop_english.py
./onestop_qa/onestop_qa.py
./oscar/oscar.py
./parsinlu_reading_comprehension/parsinlu_reading_comprehension.py
./peoples_daily_ner/peoples_daily_ner.py
./piaf/piaf.py
./pubmed/pubmed.py
./qa4mre/qa4mre.py
./qasper/qasper.py
./quail/quail.py
./ronec/ronec.py
./sberquad/sberquad.py
./sede/sede.py
./sepedi_ner/sepedi_ner.py
./sesotho_ner_corpus/sesotho_ner_corpus.py
./setswana_ner_corpus/setswana_ner_corpus.py
./siswati_ner_corpus/siswati_ner_corpus.py
./species_800/species_800.py
./spider/spider.py
./squad/squad.py
./squadshifts/squadshifts.py
./svhn/svhn.py
./swiss_judgment_prediction/swiss_judgment_prediction.py
./ted_talks_iwslt/ted_talks_iwslt.py
./trivia_qa/trivia_qa.py
./ttc4900/ttc4900.py
./turkish_movie_sentiment/turkish_movie_sentiment.py
./turkish_ner/turkish_ner.py
./turkish_product_reviews/turkish_product_reviews.py
./turkish_shrinked_ner/turkish_shrinked_ner.py
./visual_genome/visual_genome.py
./wiki40b/wiki40b.py
./wiki_dpr/wiki_dpr.py
./wiki_snippets/wiki_snippets.py
./wikipedia/wikipedia.py
./wmt14/wmt_utils.py
./wmt15/wmt_utils.py
./wmt16/wmt_utils.py
./wmt17/wmt_utils.py
./wmt18/wmt_utils.py
./wmt19/wmt_utils.py
./wmt_t2t/wmt_utils.py
./wnut_17/wnut_17.py
./yahoo_answers_qa/yahoo_answers_qa.py
./yoruba_gv_ner/yoruba_gv_ner.py
</pre>
</details>
