### PR TITLE
Modified glob to handle both local paths and object store paths. #4680

### DIFF
--- a/tensorflow_datasets/translate/wmt.py
+++ b/tensorflow_datasets/translate/wmt.py
@@ -951,7 +951,10 @@ def read_sentences(path: str) -> List[str]:
 
 
 def glob_str(glob_pattern: str) -> List[str]:
-  return [os.fspath(path) for path in epath.Path().glob(glob_pattern)]
+  # Split glob into parent_dir and target file to handle local and object store paths
+  glob_target = glob_pattern.split('/')[-1]
+  glob_parent = gcs_glob_pattern.split(glob_target)[0]
+  return [os.fspath(path) for path in epath.Path(glob_parent).glob(glob_targett)]
 
 
 def _parse_parallel_sentences(f1, f2):


### PR DESCRIPTION
* Dataset Name: wmt_t2t_translate
* Issue Reference: [wmt_t2t_translate fails build when --data_dir set to GCS location](https://github.com/tensorflow/datasets/issues/4680)

## Description

Made globbing consistent when `--data_dir` is local dir or object store path
