### PR TITLE
Set protobuf version to <=3.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ REQUIRED_PKGS = [
     'etils[enp,epath]>=0.9.0',
     'numpy',
     'promise',
-    'protobuf>=3.20',
+    'protobuf<=3.20',
     'psutil',
     'requests>=2.19.0',
     'tensorflow-metadata',


### PR DESCRIPTION
## Description
Suggested fix to resolve issue https://github.com/tensorflow/datasets/issues/4858#issuecomment-1506735950.

I am observing the exact same issues with regular `tensorflow` and setting this restriction resolved the issue.

If this is not a suitable fix, it would be nice to know why as I'm contributing to various projects which have the same issue right now.

