### PR TITLE
Run CI unittests on pull requests to the master branch

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - "master"
+      - master
   push:
     # Do not trigger tests for documentation or markdown docs.
     paths-ignore:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,9 @@ name: Unittests
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - "master"
   push:
     # Do not trigger tests for documentation or markdown docs.
     paths-ignore:


### PR DESCRIPTION
## Description

As discussed in PR https://github.com/tensorflow/datasets/pull/4865#issuecomment-1507036652, it would be beneficial to run the `unittests` CI on all pull requests to the master branch.

That way the PR maker can do an early assessment of the proposed changes after making the PR, without the need for an external reviewer.

Given that all tests pass, the code reviewer could then make his/her comments. IMO, this makes the overall code review faster and of better quality. It also reduces the time the manual reviewer needs to spend, especially on initial PR comments which tend to include minor issues which potentially the `unittests` could capture and warn the PR maker about early on.

cc: @fineguy
