### PR TITLE
Huggingface code links Fixed For First 20 Dataset Docs

### DIFF
--- a/docs/community_catalog/huggingface/acronym_identification.md
+++ b/docs/community_catalog/huggingface/acronym_identification.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/acronym_identification)
+*   [Code](https://huggingface.co/datasets/acronym_identification/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/acronym_identification)
 
 

--- a/docs/community_catalog/huggingface/ade_corpus_v2.md
+++ b/docs/community_catalog/huggingface/ade_corpus_v2.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ade_corpus_v2)
+*   [Code](https://huggingface.co/datasets/ade_corpus_v2/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ade_corpus_v2)
 
 

--- a/docs/community_catalog/huggingface/adv_glue.md
+++ b/docs/community_catalog/huggingface/adv_glue.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/adv_glue)
+*   [Code](https://huggingface.co/datasets/adv_glue/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/adv_glue)
 
 

--- a/docs/community_catalog/huggingface/adversarial_qa.md
+++ b/docs/community_catalog/huggingface/adversarial_qa.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/adversarial_qa)
+*   [Code](https://huggingface.co/datasets/adversarial_qa/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/adversarial_qa)
 
 

--- a/docs/community_catalog/huggingface/aeslc.md
+++ b/docs/community_catalog/huggingface/aeslc.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/aeslc)
+*   [Code](https://huggingface.co/datasets/aeslc/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/aeslc)
 
 

--- a/docs/community_catalog/huggingface/afrikaans_ner_corpus.md
+++ b/docs/community_catalog/huggingface/afrikaans_ner_corpus.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/afrikaans_ner_corpus)
+*   [Code](https://huggingface.co/datasets/afrikaans_ner_corpus/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/afrikaans_ner_corpus)
 
 

--- a/docs/community_catalog/huggingface/ag_news.md
+++ b/docs/community_catalog/huggingface/ag_news.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ag_news)
+*   [Code](https://huggingface.co/datasets/ag_news/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ag_news)
 
 

--- a/docs/community_catalog/huggingface/ai2_arc.md
+++ b/docs/community_catalog/huggingface/ai2_arc.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ai2_arc)
+*   [Code](https://huggingface.co/datasets/ai2_arc/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ai2_arc)
 
 

--- a/docs/community_catalog/huggingface/air_dialogue.md
+++ b/docs/community_catalog/huggingface/air_dialogue.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/air_dialogue)
+*   [Code](https://huggingface.co/datasets/air_dialogue/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/air_dialogue)
 
 

--- a/docs/community_catalog/huggingface/ajgt_twitter_ar.md
+++ b/docs/community_catalog/huggingface/ajgt_twitter_ar.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ajgt_twitter_ar)
+*   [Code](https://huggingface.co/datasets/ajgt_twitter_ar/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ajgt_twitter_ar)
 
 

--- a/docs/community_catalog/huggingface/allegro_reviews.md
+++ b/docs/community_catalog/huggingface/allegro_reviews.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/allegro_reviews)
+*   [Code](https://huggingface.co/datasets/allegro_reviews/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/allegro_reviews)
 
 

--- a/docs/community_catalog/huggingface/allocine.md
+++ b/docs/community_catalog/huggingface/allocine.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/allocine)
+*   [Code](https://huggingface.co/datasets/allocine/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/allocine)
 
 

--- a/docs/community_catalog/huggingface/alt.md
+++ b/docs/community_catalog/huggingface/alt.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/alt)
+*   [Code](https://huggingface.co/datasets/alt/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/alt)
 
 

--- a/docs/community_catalog/huggingface/amazon_polarity.md
+++ b/docs/community_catalog/huggingface/amazon_polarity.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/amazon_polarity)
+*   [Code](https://huggingface.co/datasets/amazon_polarity/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/amazon_polarity)
 
 

--- a/docs/community_catalog/huggingface/amazon_reviews_multi.md
+++ b/docs/community_catalog/huggingface/amazon_reviews_multi.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/amazon_reviews_multi)
+*   [Code](https://huggingface.co/datasets/amazon_reviews_multi/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/amazon_reviews_multi)
 
 

--- a/docs/community_catalog/huggingface/amazon_us_reviews.md
+++ b/docs/community_catalog/huggingface/amazon_us_reviews.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/amazon_us_reviews)
+*   [Code](https://huggingface.co/datasets/amazon_us_reviews/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/amazon_us_reviews)
 
 

--- a/docs/community_catalog/huggingface/ambig_qa.md
+++ b/docs/community_catalog/huggingface/ambig_qa.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ambig_qa)
+*   [Code](https://huggingface.co/datasets/ambig_qa/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ambig_qa)
 
 

--- a/docs/community_catalog/huggingface/americas_nli.md
+++ b/docs/community_catalog/huggingface/americas_nli.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/americas_nli)
+*   [Code](https://huggingface.co/datasets/americas_nli/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/americas_nli)
 
 

--- a/docs/community_catalog/huggingface/ami.md
+++ b/docs/community_catalog/huggingface/ami.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ami)
+*   [Code](https://huggingface.co/datasets/ami/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ami)
 
 

--- a/docs/community_catalog/huggingface/amttl.md
+++ b/docs/community_catalog/huggingface/amttl.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/amttl)
+*   [Code](https://huggingface.co/datasets/amttl/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/amttl)
 
 


### PR DESCRIPTION
## Description
Hugging Face datasets are moved from Github to Hugging Face Hub. Tensorflow Dataset Docs still have older links.
This PR Fixes the Links to Code of First 20 Files namely:

1. acronym_identification
2. ade_corpus_v2
3. adv_glue
4. adversarial_qa
5. aeslc
6. afrikaans_ner_corpus
7. ag_news
8. ai2_arc
9. air_dialogue
10. ajgt_twitter_ar
11. allegro_reviews
12. allocine
13. alt
14. amazon_polarity
15. amazon_reviews_multi
16. amazon_us_reviews
17. ambig_qa
18. americas_nli
19. ami
20. amttl




















