### PR TITLE
Huggingface code links 2

### DIFF
--- a/docs/community_catalog/huggingface/anli.md
+++ b/docs/community_catalog/huggingface/anli.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/anli)
+*   [Code](https://huggingface.co/datasets/anli/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/anli)
 
 

--- a/docs/community_catalog/huggingface/app_reviews.md
+++ b/docs/community_catalog/huggingface/app_reviews.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/app_reviews)
+*   [Code](https://huggingface.co/datasets/app_reviews/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/app_reviews)
 
 

--- a/docs/community_catalog/huggingface/aqua_rat.md
+++ b/docs/community_catalog/huggingface/aqua_rat.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/aqua_rat)
+*   [Code](https://huggingface.co/datasets/aqua_rat/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/aqua_rat)
 
 

--- a/docs/community_catalog/huggingface/aquamuse.md
+++ b/docs/community_catalog/huggingface/aquamuse.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/aquamuse)
+*   [Code](https://huggingface.co/datasets/aquamuse/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/aquamuse)
 
 

--- a/docs/community_catalog/huggingface/ar_cov19.md
+++ b/docs/community_catalog/huggingface/ar_cov19.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ar_cov19)
+*   [Code](https://huggingface.co/datasets/ar_cov19/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ar_cov19)
 
 

--- a/docs/community_catalog/huggingface/ar_res_reviews.md
+++ b/docs/community_catalog/huggingface/ar_res_reviews.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ar_res_reviews)
+*   [Code](https://huggingface.co/datasets/ar_res_reviews/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ar_res_reviews)
 
 

--- a/docs/community_catalog/huggingface/ar_sarcasm.md
+++ b/docs/community_catalog/huggingface/ar_sarcasm.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ar_sarcasm)
+*   [Code](https://huggingface.co/datasets/ar_sarcasm/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ar_sarcasm)
 
 

--- a/docs/community_catalog/huggingface/arabic_billion_words.md
+++ b/docs/community_catalog/huggingface/arabic_billion_words.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/arabic_billion_words)
+*   [Code](https://huggingface.co/datasets/arabic_billion_words/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/arabic_billion_words)
 
 

--- a/docs/community_catalog/huggingface/arabic_pos_dialect.md
+++ b/docs/community_catalog/huggingface/arabic_pos_dialect.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/arabic_pos_dialect)
+*   [Code](https://huggingface.co/datasets/arabic_pos_dialect/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/arabic_pos_dialect)
 
 

--- a/docs/community_catalog/huggingface/arabic_speech_corpus.md
+++ b/docs/community_catalog/huggingface/arabic_speech_corpus.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/arabic_speech_corpus)
+*   [Code](https://huggingface.co/datasets/arabic_speech_corpus/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/arabic_speech_corpus)
 
 

--- a/docs/community_catalog/huggingface/arcd.md
+++ b/docs/community_catalog/huggingface/arcd.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/arcd)
+*   [Code](https://huggingface.co/datasets/arcd/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/arcd)
 
 

--- a/docs/community_catalog/huggingface/arsentd_lev.md
+++ b/docs/community_catalog/huggingface/arsentd_lev.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/arsentd_lev)
+*   [Code](https://huggingface.co/datasets/arsentd_lev/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/arsentd_lev)
 
 

--- a/docs/community_catalog/huggingface/art.md
+++ b/docs/community_catalog/huggingface/art.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/art)
+*   [Code](https://huggingface.co/datasets/art/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/art)
 
 

--- a/docs/community_catalog/huggingface/arxiv_dataset.md
+++ b/docs/community_catalog/huggingface/arxiv_dataset.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/arxiv_dataset)
+*   [Code](https://huggingface.co/datasets/arxiv_dataset/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/arxiv_dataset)
 
 

--- a/docs/community_catalog/huggingface/ascent_kb.md
+++ b/docs/community_catalog/huggingface/ascent_kb.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/ascent_kb)
+*   [Code](https://huggingface.co/datasets/ascent_kb/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/ascent_kb)
 
 

--- a/docs/community_catalog/huggingface/aslg_pc12.md
+++ b/docs/community_catalog/huggingface/aslg_pc12.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/aslg_pc12)
+*   [Code](https://huggingface.co/datasets/aslg_pc12/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/aslg_pc12)
 
 

--- a/docs/community_catalog/huggingface/asnq.md
+++ b/docs/community_catalog/huggingface/asnq.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/asnq)
+*   [Code](https://huggingface.co/datasets/asnq/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/asnq)
 
 

--- a/docs/community_catalog/huggingface/asset.md
+++ b/docs/community_catalog/huggingface/asset.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/asset)
+*   [Code](https://huggingface.co/datasets/asset/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/asset)
 
 

--- a/docs/community_catalog/huggingface/assin.md
+++ b/docs/community_catalog/huggingface/assin.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/assin)
+*   [Code](https://huggingface.co/datasets/assin/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/assin)
 
 

--- a/docs/community_catalog/huggingface/assin2.md
+++ b/docs/community_catalog/huggingface/assin2.md
@@ -2,7 +2,7 @@
 
 References:
 
-*   [Code](https://github.com/huggingface/datasets/blob/master/datasets/assin2)
+*   [Code](https://huggingface.co/datasets/assin2/tree/main)
 *   [Huggingface](https://huggingface.co/datasets/assin2)
 
 


### PR DESCRIPTION
Hugging Face datasets are moved from Github to Hugging Face Hub. Tensorflow Dataset Docs still have older links.
This PR Fixes the Links to Code of 21-40 Files namely:

21 | anli
22 | app_reviews
23 | aqua_rat
24 | aquamuse
25 | ar_cov19
26 | ar_res_reviews
27 | ar_sarcasm
28 | arabic_billion_words
29 | arabic_pos_dialect
30 | arabic_speech_corpus
31 | arcd
32 | arsentd_lev
33 | art
34 | arxiv_dataset
35 | ascent_kb
36 | aslg_pc12
37 | asnq
38 | asset
39 | assin
40 | assin2

(Note: PR for Updating first 20 Docs is already created)
