### PR TITLE
Fix for bug 2889 - Loading SUN397 crashed.

### DIFF
--- a/tensorflow_datasets/datasets/sun397/sun397_dataset_builder.py
+++ b/tensorflow_datasets/datasets/sun397/sun397_dataset_builder.py
@@ -30,6 +30,7 @@ _SUN397_URL = "https://vision.princeton.edu/projects/2010/SUN/"
 # decoding is not deterministic (PIL).
 _SUN397_IGNORE_IMAGES = [
     "SUN397/c/church/outdoor/sun_bhenjvsvrtumjuri.jpg",
+    "SUN397/t/track/outdoor/sun_aophkoiosslinihb.jpg",
 ]
 
 _SUN397_BUILDER_CONFIG_DESCRIPTION_PATTERN = (
@@ -270,6 +271,8 @@ class Builder(tfds.core.GeneratorBasedBuilder):
     with tf.Graph().as_default():
       with utils.nogpu_session() as sess:
         for filepath, fobj in archive:
+          if filepath in _SUN397_IGNORE_IMAGES:
+            continue
           # Note: all files in the tar.gz are in SUN397/...
           filename = filepath[prefix_len:].replace("\\", "/")  # For windows
           if filename in subset_images:


### PR DESCRIPTION
This commit fixes the bug related to sun397. It utilizes the `_SUN397_IGNORE_IMAGES` list containing the two problematic images to skip during the image generation. Thus it solves the crash issue.

Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Add Dataset

* Dataset Name: sun397
* Issue Reference: [#2889](https://github.com/tensorflow/datasets/issues/2889)


