### PR TITLE
WAR bad array_record wheel on arm64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,10 @@ DOCLINES = __doc__.split('\n')
 
 REQUIRED_PKGS = [
     'absl-py',
-    'array_record',
+# Min version of 0.5.0 as old array_record wheel are bugged on all
+# platform except 'x86_64'. See
+# https://github.com/google/array_record/issues/71
+    'array_record>=0.5.0',
     'click',
     'dm-tree',
     'etils[enp,epath,etree]>=0.9.0',


### PR DESCRIPTION
This WAR a bug in array_record:
https://github.com/google/array_record/issues/71

Mostly, all old pip wheel only work on x86_64, but get installed on all platform as the wheel is marked as platform independent.

A fix was merged in array_record, but no new wheel is made yet.
This PR make sure that we will crash the installation until a new release is done on all non-x86_64 platform. When the release is done, it will make sure to not install older version.