### PR TITLE
cats_vs_dogs: recoding image on generate samples to fix corrupted images

### DIFF
--- a/tensorflow_datasets/image_classification/cats_vs_dogs.py
+++ b/tensorflow_datasets/image_classification/cats_vs_dogs.py
@@ -97,13 +97,20 @@ class CatsVsDogs(tfds.core.GeneratorBasedBuilder):
       if tf.compat.as_bytes("JFIF") not in fobj.peek(10):
         num_skipped += 1
         continue
+
+      # some images caused 'Corrupt JPEG data...' messages during training or any other iteration
+      # recoding them once fixes the issue (discussion: https://github.com/tensorflow/datasets/issues/2188)
+      # those messages are now displayed when generating the dataset instead
       img_data = fobj.read()
       img_tensor = tf.image.decode_image(img_data)
       img_recoded = tf.io.encode_jpeg(img_tensor)
+
+      # converting the recoded image back into a zip file container
       buffer = io.BytesIO()
       with zipfile.ZipFile(buffer, 'w') as new_zip:
-          new_zip.writestr(fname, img_recoded.numpy())
+        new_zip.writestr(fname, img_recoded.numpy())
       new_fobj = zipfile.ZipFile(buffer).open(fname)
+
       record = {
           "image": new_fobj,
           "image/filename": fname,

--- a/tensorflow_datasets/image_classification/cats_vs_dogs.py
+++ b/tensorflow_datasets/image_classification/cats_vs_dogs.py
@@ -16,6 +16,8 @@
 """Cats vs Dogs dataset."""
 
 import re
+import io
+import zipfile
 
 from absl import logging
 from tensorflow_datasets.core.utils.lazy_imports_utils import tensorflow as tf
@@ -95,8 +97,15 @@ class CatsVsDogs(tfds.core.GeneratorBasedBuilder):
       if tf.compat.as_bytes("JFIF") not in fobj.peek(10):
         num_skipped += 1
         continue
+      img_data = fobj.read()
+      img_tensor = tf.image.decode_image(img_data)
+      img_recoded = tf.io.encode_jpeg(img_tensor)
+      buffer = io.BytesIO()
+      with zipfile.ZipFile(buffer, 'w') as new_zip:
+          new_zip.writestr(fname, img_recoded.numpy())
+      new_fobj = zipfile.ZipFile(buffer).open(fname)
       record = {
-          "image": fobj,
+          "image": new_fobj,
           "image/filename": fname,
           "label": label,
       }

--- a/tensorflow_datasets/image_classification/cats_vs_dogs.py
+++ b/tensorflow_datasets/image_classification/cats_vs_dogs.py
@@ -52,9 +52,10 @@ _NAME_RE = re.compile(r"^PetImages[\\/](Cat|Dog)[\\/]\d+\.jpg$")
 class CatsVsDogs(tfds.core.GeneratorBasedBuilder):
   """Cats vs Dogs."""
 
-  VERSION = tfds.core.Version("4.0.0")
+  VERSION = tfds.core.Version("4.0.1")
   RELEASE_NOTES = {
       "4.0.0": "New split API (https://tensorflow.org/datasets/splits)",
+      "4.0.1": "Recoding images in generator to fix corrupt JPEG data warnings (https://github.com/tensorflow/datasets/issues/2188)"
   }
 
   def _info(self):


### PR DESCRIPTION
This is a proposal to fix https://github.com/tensorflow/datasets/issues/2188.
@eclarson suggested to use `decode_image` and `recode_jpeg` in https://github.com/tensorflow/datasets/issues/2188#issuecomment-1403126938 to rewrite the images, which fixes them (12 out of 25000 are corrupted, one additional has a defective JFIF revision number). Kudos to him, I am just putting it into a PR.

I added those lines into the `_generate_examples` function. It is executed only once when extracting the archive, which means:
* the additional computation time for recoding the images is only needed once
* users might have to delete their local copy of the dataset to generate it again with the fixes
* the errors are still displayed, but when generating the dataset instead of during training or inference

Note: I am not familiar with contributing to python projects like tensorflow, but tried to follow the contribution guide. Please let me know if I am missing something.