### PR TITLE
Fix PASS Dataset Builder filepath in Windows Platforms

### DIFF
--- a/tensorflow_datasets/datasets/pass/pass_dataset_builder.py
+++ b/tensorflow_datasets/datasets/pass/pass_dataset_builder.py
@@ -95,7 +95,7 @@ class Builder(tfds.core.GeneratorBasedBuilder):
     for part in parts:
       for fname, fobj in dl_manager.iter_archive(part):
         i += 1
-        img_hash = fname.split('/')[-1].split('.')[0]
+        img_hash = os.path.split(fname)[-1].split('.')[0]
         img_meta = meta.loc[img_hash]
 
         record = {

--- a/tensorflow_datasets/datasets/pass/pass_dataset_builder.py
+++ b/tensorflow_datasets/datasets/pass/pass_dataset_builder.py
@@ -15,6 +15,7 @@
 
 """PASS dataset."""
 
+import os
 import numpy as np
 from tensorflow_datasets.core.utils.lazy_imports_utils import tensorflow as tf
 import tensorflow_datasets.public_api as tfds


### PR DESCRIPTION
Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Fix Dataset

* Dataset Name: PASS
* Issue Reference: https://github.com/tensorflow/datasets/issues/1911
* `dataset_info.json` Gist: <link>

## Description

I ran across this issue playing with PASS tfds on Windows. I got KeyError in pandas during download_and_prepare. The root cause seems to be PASS Builder does not account for Windows path separator being back slash `\` instead of Linux `/`. This fix uses python standard os.path.split instead. 
I'm using the placeholder issue for windows. Let me know if there's a better fit. Thanks

## Checklist

* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
