### PR TITLE
[Fix] Full update of data_dir in DatasetInfo with update_data_dir()

### DIFF
--- a/tensorflow_datasets/core/dataset_info.py
+++ b/tensorflow_datasets/core/dataset_info.py
@@ -538,7 +538,7 @@ class DatasetInfo(object):
         self.as_proto.splits.add().CopyFrom(split_info.to_proto())
 
   def update_data_dir(self, data_dir: str) -> None:
-    """Updates the data dir for each split."""
+    """Updates the data dir and data dir for each split."""
     new_split_infos = []
     for split_info in self._splits.values():
       if isinstance(split_info, splits_lib.MultiSplitInfo):
@@ -553,6 +553,7 @@ class DatasetInfo(object):
       new_split_info = split_info.replace(filename_template=filename_template)
       new_split_infos.append(new_split_info)
     self.set_splits(splits_lib.SplitDict(new_split_infos))
+    self._identity.data_dir = target_dir
 
   @property
   def initialized(self) -> bool:


### PR DESCRIPTION
## Description

The previous `DatasetInfo.update_data_dir()` only updates the datadir in each split, but not its DatasetIdentity, making the update incomplete. The datadir property doesn't have a setter too, thus, this adds a single liner to update the identity when the update_data_dir() is called.
