### PR TITLE
fix bug of canot load EMNIST dataset #5356

### DIFF
--- a/tensorflow_datasets/image_classification/mnist.py
+++ b/tensorflow_datasets/image_classification/mnist.py
@@ -258,7 +258,7 @@ class EMNISTConfig(tfds.core.BuilderConfig):
 class EMNIST(MNIST):
   """Emnist dataset."""
 
-  URL = "https://www.itl.nist.gov/iaui/vip/cs_links/EMNIST/gzip.zip"
+  URL = "https://biometrics.nist.gov/cs_links/EMNIST/gzip.zip"
   VERSION = tfds.core.Version("3.0.0")
   RELEASE_NOTES = {
       "3.0.0": "New split API (https://tensorflow.org/datasets/splits)",


### PR DESCRIPTION
## Description
The current MNIST URL - https://www.itl.nist.gov/iaui/vip/cs_links/EMNIST/gzip.zip is outdated which gives the `NonMatchingChecksumError` whenever `tfds.image_classification.EMNIST` is called.
Simply changed to working URL - https://biometrics.nist.gov/cs_links/EMNIST/gzip.zip which gives the same `gzip.zip` file.
This was first issued by [davidshen84](https://github.com/davidshen84) [here](https://github.com/tensorflow/datasets/issues/5356) and found the working URL. Hurray for davidshen84!
<description>
