### PR TITLE
fix sentiment140 download url 404 error

### DIFF
--- a/tensorflow_datasets/datasets/sentiment140/sentiment140_dataset_builder.py
+++ b/tensorflow_datasets/datasets/sentiment140/sentiment140_dataset_builder.py
@@ -25,7 +25,7 @@ import numpy as np
 from tensorflow_datasets.core.utils.lazy_imports_utils import tensorflow as tf
 import tensorflow_datasets.public_api as tfds
 
-_DOWNLOAD_URL = "http://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip"
+_DOWNLOAD_URL = "https://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip"
 _HOMEPAGE_URL = "http://help.sentiment140.com/home"
 
 


### PR DESCRIPTION
The original URL already enabled https. https://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip

Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Add Dataset

* Dataset Name: sentiment140
* Issue Reference: <link>
* `dataset_info.json` Gist: <link>

## Description
Got 404 error with the following code, since the current http url `http://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip` will be auto redirected to `https://www.cs.stanford.edu/people/alecmgo/trainingandtestdata.zip`, which does not exist.

```
dataset, info = tfds.load(
    name="sentiment140",
    with_info=True
)
```

## Checklist

* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
