### PR TITLE
Fix issue with transformers library huggingface

### DIFF
--- a/tensorflow_datasets/core/community/huggingface_wrapper.py
+++ b/tensorflow_datasets/core/community/huggingface_wrapper.py
@@ -27,6 +27,7 @@ import types
 from typing import Iterator, NamedTuple, Optional, Union
 from unittest import mock
 
+from importlib.machinery import ModuleSpec
 from etils import epath
 from tensorflow_datasets.core import dataset_builder
 from tensorflow_datasets.core import dataset_info
@@ -248,7 +249,7 @@ class _MockedHFDatasets(types.ModuleType):
 
   def __init__(self):
     super().__init__('datasets')
-
+    self.__spec__  = ModuleSpec('datasets', None)
   # pylint: disable=invalid-name
 
   Version = Version


### PR DESCRIPTION
## Description

I was trying to modifiy a RLDS dataset built on top of TFDS following this repo : https://github.com/kpertsch/rlds_dataset_builder 
I needed to extract some features from images with models from the transformers library of HuggingFace but was facing an issue during the import : ```raise ValueError('{}.__spec__ is None'.format(name))
ValueError: datasets.__spec__ is None```

And more specifically this one : ```transformers/utils/import_utils.py", line 120, in <module>
    _datasets_available = _is_package_available("datasets")```

It verifies if `datasets` (the HF library) is available by looking at the `__spec__` attribute. As tfds is overwritting datasets by a mock, it does not create the attribute, which causes the issue.

In the PR I fixed the issue by simply creating the needed attribute in the Mock in order to solve the problem.

Here are the versions of the libraries involved in the problem :
`tensorflow-datasets          4.9.3`
`transformers                 4.50.0.dev0` 

