### PR TITLE
Fix shard computation in `NoShuffleBeamWriter` with overlapping split names

### DIFF
--- a/tensorflow_datasets/core/writer.py
+++ b/tensorflow_datasets/core/writer.py
@@ -817,7 +817,7 @@ class NoShuffleBeamWriter:
     # We don't know the number of shards, the length of each shard, nor the
     # total size, so we compute them here.
     prefix = epath.Path(self._filename_template.filepath_prefix())
-    shards = self._filename_template.data_dir.glob(f"{prefix.name}*")
+    shards = self._filename_template.data_dir.glob(f"{prefix.name}.*")
 
     def _get_length_and_size(shard: epath.Path) -> tuple[epath.Path, int, int]:
       length = self._file_adapter.num_examples(shard)

--- a/tensorflow_datasets/core/writer_test.py
+++ b/tensorflow_datasets/core/writer_test.py
@@ -592,39 +592,40 @@ class NoShuffleBeamWriterTest(parameterized.TestCase):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
       tmp_dir = epath.Path(tmp_dir)
-      filename_template = naming.ShardedFileTemplate(
-          dataset_name='foo',
-          split='train',
-          filetype_suffix=file_format.file_suffix,
-          data_dir=tmp_dir,
-      )
-      writer = writer_lib.NoShuffleBeamWriter(
-          serializer=testing.DummySerializer('dummy specs'),
-          filename_template=filename_template,
-          file_format=file_format,
-      )
-      to_write = [(i, str(i).encode('utf-8')) for i in range(10)]
-      # Here we need to disable type check as `beam.Create` is not capable of
-      # inferring the type of the PCollection elements.
-      options = beam.options.pipeline_options.PipelineOptions(
-          pipeline_type_check=False
-      )
-      with beam.Pipeline(options=options, runner=_get_runner()) as pipeline:
+      for split in ('train-b', 'train'):
+        filename_template = naming.ShardedFileTemplate(
+            dataset_name='foo',
+            split=split,
+            filetype_suffix=file_format.file_suffix,
+            data_dir=tmp_dir,
+        )
+        writer = writer_lib.NoShuffleBeamWriter(
+            serializer=testing.DummySerializer('dummy specs'),
+            filename_template=filename_template,
+            file_format=file_format,
+        )
+        to_write = [(i, str(i).encode('utf-8')) for i in range(10)]
+        # Here we need to disable type check as `beam.Create` is not capable
+        # of inferring the type of the PCollection elements.
+        options = beam.options.pipeline_options.PipelineOptions(
+            pipeline_type_check=False
+        )
+        with beam.Pipeline(options=options, runner=_get_runner()) as pipeline:
 
-        @beam.ptransform_fn
-        def _build_pcollection(pipeline):
-          pcollection = pipeline | 'Start' >> beam.Create(to_write)
-          return writer.write_from_pcollection(pcollection)
+          @beam.ptransform_fn
+          def _build_pcollection(pipeline):
+            pcollection = pipeline | 'Start' >> beam.Create(to_write)
+            return writer.write_from_pcollection(pcollection)
 
-        _ = pipeline | 'test' >> _build_pcollection()  # pylint: disable=no-value-for-parameter
-      shard_lengths, total_size = writer.finalize()
-      self.assertNotEmpty(shard_lengths)
-      self.assertEqual(sum(shard_lengths), 10)
-      self.assertGreater(total_size, 10)
-      files = list(tmp_dir.iterdir())
-      self.assertGreaterEqual(len(files), 1)
-      for f in files:
-        self.assertIn(file_format.file_suffix, f.name)
+          _ = pipeline | 'test' >> _build_pcollection()  # pylint: disable=no-value-for-parameter
+        shard_lengths, total_size = writer.finalize()
+        self.assertNotEmpty(shard_lengths)
+        self.assertEqual(sum(shard_lengths), 10)
+        self.assertGreater(total_size, 10)
+        files = list(tmp_dir.iterdir())
+        self.assertGreaterEqual(len(files), 1)
+        for f in files:
+          self.assertIn(file_format.file_suffix, f.name)
 
 
 class CustomExampleWriter(writer_lib.ExampleWriter):


### PR DESCRIPTION
Currently `NoShuffleBeamWriter` would compute the wrong number of shards for cases where splits have overlapping names.

E.g. given a dataset with two splits `foo` and `foo_bar` the generated tfrecord files would look something like this:
```
builder-foo.tfrecord-00000-of-00003
builder-foo.tfrecord-00001-of-00003
builder-foo.tfrecord-00002-of-00003
builder-foo_bar.tfrecord-00000-of-00002
builder-foo_bar.tfrecord-00001-of-00002
````
The current regex for the `foo` split would be `builder-foo*` which also matches the files of the `foo_bar` split. This results in the number of shards for `foo` to also include shards from the other split. This fixes it by changing the regex to `builder-foo.*`.