### PR TITLE
Update the cars196 dataset

### DIFF
--- a/tensorflow_datasets/image_classification/cars196.py
+++ b/tensorflow_datasets/image_classification/cars196.py
@@ -20,8 +20,8 @@ import urllib
 from tensorflow_datasets.core.utils.lazy_imports_utils import tensorflow as tf
 import tensorflow_datasets.public_api as tfds
 
-_URL = 'http://ai.stanford.edu/~jkrause/car196/'
-_EXTRA_URL = 'https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz'
+_URL = 'https://web.archive.org/web/20221212053154/http://ai.stanford.edu/~jkrause/car196/'
+_EXTRA_URL = 'https://web.archive.org/web/20230323151230/https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz'
 
 _DESCRIPTION = (
     'The Cars dataset contains 16,185 images of 196 classes of cars. The data '

--- a/tensorflow_datasets/image_classification/cars196.py
+++ b/tensorflow_datasets/image_classification/cars196.py
@@ -271,7 +271,7 @@ class Cars196(tfds.core.GeneratorBasedBuilder):
         description=(_DESCRIPTION),
         features=tfds.features.FeaturesDict(features_dict),
         supervised_keys=('image', 'label'),
-        homepage='https://ai.stanford.edu/~jkrause/cars/car_dataset.html',
+        homepage='https://web.archive.org/web/20230323151220/https://ai.stanford.edu/~jkrause/cars/car_dataset.html',
         citation=_CITATION,
     )
 

--- a/tensorflow_datasets/url_checksums/cars196.txt
+++ b/tensorflow_datasets/url_checksums/cars196.txt
@@ -2,3 +2,7 @@ http://ai.stanford.edu/~jkrause/car196/cars_test.tgz	977350468	bffea656d6f425cba
 http://ai.stanford.edu/~jkrause/car196/cars_test_annos_withlabels.mat	185758	790f75be8ea34eeded134cc559332baf23e30e91367e9ddca97d26ed9b895f05	cars_test_annos_withlabels.mat
 http://ai.stanford.edu/~jkrause/car196/cars_train.tgz	979269282	512b227b30e2f0a8aab9e09485786ab4479582073a144998da74d64b801fd288	cars_train.tgz
 https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz	330960	b97deb463af7d58b6bfaa18b2a4de9829f0f79e8ce663dfa9261bf7810e9accd	car_devkit.tgz
+https://web.archive.org/web/20221212053154/http:/ai.stanford.edu/~jkrause/car196/cars_test.tgz	977350468	bffea656d6f425cba3c91c6d83336e4c5f86c6cffd8975b0f375d3a10da8e243	cars_test.tgz
+https://web.archive.org/web/20221212053154/http:/ai.stanford.edu/~jkrause/car196/cars_test_annos_withlabels.mat	185758	790f75be8ea34eeded134cc559332baf23e30e91367e9ddca97d26ed9b895f05	cars_test_annos_withlabels.mat
+https://web.archive.org/web/20221212053154/http:/ai.stanford.edu/~jkrause/car196/cars_train.tgz	979269282	512b227b30e2f0a8aab9e09485786ab4479582073a144998da74d64b801fd288	cars_train.tgz
+https://web.archive.org/web/20230323151230/https://ai.stanford.edu/~jkrause/cars/car_devkit.tgz	330960	b97deb463af7d58b6bfaa18b2a4de9829f0f79e8ce663dfa9261bf7810e9accd	car_devkit.tgz


### PR DESCRIPTION
## Description

- Update the URLs in the image_classification/cars196 dataset. 
  - Note: The previous URL pointed to ai.stanford.edu/~jkrause/cars which doesn't work anymore unfortunately. 
  - I updated it to use webarchive links of the corresponding urls.
- Update checksums.
- Fixes #5656 and #5053.
