### PR TITLE
Update caltech birds 2011 dataset

### DIFF
--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -233,7 +233,8 @@ class CaltechBirds2011(CaltechBirds2010):
   def _caltech_birds_info(self):
     return CaltechBirdsInfo2011(
         name=self.name,
-        combined_url="https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1"
+        images_url="https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1",
+        segmentations_url="https://data.caltech.edu/records/w9d68-gec53/files/segmentations.tgz?download=1"
         # images_url="https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
         # split_url=None,
         # annotations_url="https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP",
@@ -374,12 +375,13 @@ class CaltechBirdsInfo(
 class CaltechBirdsInfo2011(
     collections.namedtuple(
         "_CaltechBirdsInfo2011",
-        ["name", "combined_url"],
+        ["name", "images_urls", "segmentations_url"],
     )
 ):
   """Contains the information necessary to generate a Caltech Birds 2011 dataset.
 
   Args:
       name (str): name of dataset.
-      combined_url (str): URL containing images and attributes.
+      images_urls (str): URL containing images
+      segmentations_url (str): URL containing segmentations.
   """

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -376,13 +376,13 @@ class CaltechBirdsInfo(
 class CaltechBirdsInfo2011(
     collections.namedtuple(
         "_CaltechBirdsInfo2011",
-        ["name", "images_urls", "segmentations_url"],
+        ["name", "images_url", "segmentations_url"],
     )
 ):
   """Contains the information necessary to generate a Caltech Birds 2011 dataset.
 
   Args:
       name (str): name of dataset.
-      images_urls (str): URL containing images
+      images_url (str): URL containing images
       segmentations_url (str): URL containing segmentations.
   """

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -260,13 +260,12 @@ class CaltechBirds2011(CaltechBirds2010):
   def _split_generators(self, dl_manager):
     download_path = dl_manager.download(
         [
-            self._caltech_birds_info.images_url,
+            self._caltech_birds_info.combined_url,
         ]
     )
 
     extracted_path = dl_manager.download_and_extract([
-        self._caltech_birds_info.images_url,
-        self._caltech_birds_info.annotations_url,
+        self._caltech_birds_info.combined_url,
     ])
 
     image_names_path = os.path.join(

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -261,12 +261,13 @@ class CaltechBirds2011(CaltechBirds2010):
   def _split_generators(self, dl_manager):
     download_path = dl_manager.download(
         [
-            self._caltech_birds_info.combined_url,
+            self._caltech_birds_info.images_url,
         ]
     )
 
     extracted_path = dl_manager.download_and_extract([
-        self._caltech_birds_info.combined_url,
+        self._caltech_birds_info.images_url,
+        self._caltech_birds_info.segmentations_url
     ])
 
     image_names_path = os.path.join(

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -231,9 +231,9 @@ class CaltechBirds2011(CaltechBirds2010):
 
   @property
   def _caltech_birds_info(self):
-    return CaltechBirdsInfo(
+    return CaltechBirdsInfo2011(
         name=self.name,
-        combined_url="https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1",
+        combined_url="https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1"
         # images_url="https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
         # split_url=None,
         # annotations_url="https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP",
@@ -371,3 +371,16 @@ class CaltechBirdsInfo(
       annotations_url (str): annotation folder URL.
   """
 
+
+class CaltechBirdsInfo2011(
+    collections.namedtuple(
+        "_CaltechBirdsInfo2011",
+        ["name", "combined_url"],
+    )
+):
+  """Contains the information necessary to generate a Caltech Birds 2011 dataset.
+
+  Args:
+      name (str): name of dataset.
+      combined_url (str): URL containing images and attributes.
+  """

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -384,3 +384,4 @@ class CaltechBirdsInfo2011(
       images_url (str): URL containing images
       segmentations_url (str): URL containing segmentations.
   """
+

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -233,9 +233,10 @@ class CaltechBirds2011(CaltechBirds2010):
   def _caltech_birds_info(self):
     return CaltechBirdsInfo(
         name=self.name,
-        images_url="https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
-        split_url=None,
-        annotations_url="https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP",
+        combined_url="https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1",
+        # images_url="https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
+        # split_url=None,
+        # annotations_url="https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP",
     )
 
   def _info(self):
@@ -369,3 +370,4 @@ class CaltechBirdsInfo(
       split_url (str): train/test split file URL.
       annotations_url (str): annotation folder URL.
   """
+

--- a/tensorflow_datasets/image_classification/caltech_birds.py
+++ b/tensorflow_datasets/image_classification/caltech_birds.py
@@ -234,7 +234,7 @@ class CaltechBirds2011(CaltechBirds2010):
     return CaltechBirdsInfo2011(
         name=self.name,
         images_url="https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1",
-        segmentations_url="https://data.caltech.edu/records/w9d68-gec53/files/segmentations.tgz?download=1"
+        segmentations_url="https://data.caltech.edu/records/w9d68-gec53/files/segmentations.tgz?download=1",
         # images_url="https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
         # split_url=None,
         # annotations_url="https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP",
@@ -259,15 +259,13 @@ class CaltechBirds2011(CaltechBirds2010):
     )
 
   def _split_generators(self, dl_manager):
-    download_path = dl_manager.download(
-        [
-            self._caltech_birds_info.images_url,
-        ]
-    )
+    download_path = dl_manager.download([
+        self._caltech_birds_info.images_url,
+    ])
 
     extracted_path = dl_manager.download_and_extract([
         self._caltech_birds_info.images_url,
-        self._caltech_birds_info.segmentations_url
+        self._caltech_birds_info.segmentations_url,
     ])
 
     image_names_path = os.path.join(

--- a/tensorflow_datasets/url_checksums/caltech_birds2011.txt
+++ b/tensorflow_datasets/url_checksums/caltech_birds2011.txt
@@ -1,2 +1,3 @@
+https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1	1150585339	0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081	CUB_200_2011.tgz
 https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP	39272883	dc77f6cffea0cbe2e41d4201115c8f29a6320ecb04fffd2444f51b8066e4b84f	segmentations.tgz
 https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45	1150585339	0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081	CUB_200_2011.tgz

--- a/tensorflow_datasets/url_checksums/caltech_birds2011.txt
+++ b/tensorflow_datasets/url_checksums/caltech_birds2011.txt
@@ -1,3 +1,4 @@
 https://data.caltech.edu/records/65de6-vp158/files/CUB_200_2011.tgz?download=1	1150585339	0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081	CUB_200_2011.tgz
+https://data.caltech.edu/records/w9d68-gec53/files/segmentations.tgz?download=1	39272883	dc77f6cffea0cbe2e41d4201115c8f29a6320ecb04fffd2444f51b8066e4b84f	segmentations.tgz
 https://drive.google.com/uc?export=download&id=1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP	39272883	dc77f6cffea0cbe2e41d4201115c8f29a6320ecb04fffd2444f51b8066e4b84f	segmentations.tgz
 https://drive.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45	1150585339	0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081	CUB_200_2011.tgz


### PR DESCRIPTION
## Caltech Bird 2011 Dataset

## Description
- Update urls for Caltech birds 2011 dataset
  - Update images url to new path hosted by Caltech (https://data.caltech.edu/records/65de6-vp158).
  - Add a segmentations url and update the class.
- Update checksums.
 - Fixes #11041 11041 

