### PR TITLE
Fix rlds `episode_metadata`

### DIFF
--- a/tensorflow_datasets/rlds/rlds_base.py
+++ b/tensorflow_datasets/rlds/rlds_base.py
@@ -75,6 +75,8 @@ def build_info(
   episode_metadata = ds_config.episode_metadata_info
   if episode_metadata is None:
     episode_metadata = {}
+  else:
+    episode_metadata = {"episode_metadata": episode_metadata}
   step_info = {
       'is_terminal': tf.bool,
       'is_first': tf.bool,


### PR DESCRIPTION
This PR fixes rlds's `build_info` when `episode_metadata` is not None

## Reproduce
```python
from tensorflow_datasets.rlds import rlds_base
features = rlds_base.build_info(
    rlds_base.DatasetConfig(
        name="xxx",
        steps={xxx},
        episode_metadata_info={
            "test": tfds.features.Text()
        }
    ),
    self,
)
print(features)

features=FeaturesDict({
    'steps': Dataset({
        ...
    }),
    'test': Text(shape=(), dtype=string),
}),
```

Currently, the returned features will get rid of `episode_metadata` key, which is not consistent with widely used rlds dataset:
- [robomimic](https://github.com/jhejna/demonstration-information/blob/main/rlds/robomimic/robomimic_dataset_builder.py#L91-L100)
- [bridge](https://www.tensorflow.org/datasets/catalog/bridge)
- ...
- All datasets listed in [`official tensorflow datasets robotics`](https://www.tensorflow.org/datasets/catalog/aloha_mobile)

