### PR TITLE
Fix MSLR-WEB dataset download URLs

### DIFF
--- a/tensorflow_datasets/ranking/mslr_web/mslr_web.py
+++ b/tensorflow_datasets/ranking/mslr_web/mslr_web.py
@@ -61,8 +61,8 @@ _CITATION = """
 """
 
 _URLS = {
-    "10k": "https://api.onedrive.com/v1.0/shares/s!AtsMfWUz5l8nbOIoJ6Ks0bEMp78/root/content",
-    "30k": "https://api.onedrive.com/v1.0/shares/s!AtsMfWUz5l8nbXGPBlwD1rnFdBY/root/content",
+    "10k": "https://1drv.ms/u/s!AtsMfWUz5l8nbOIoJ6Ks0bEMp78",
+    "30k": "https://1drv.ms/u/s!AtsMfWUz5l8nbXGPBlwD1rnFdBY",
 }
 
 _FEATURE_NAMES = {


### PR DESCRIPTION
Fixes #11136

## Problem
The MSLR-WEB dataset download was failing with HTTP 400 errors because the old OneDrive API v1.0 URLs are deprecated.

## Solution
Updated the download URLs to the new OneDrive share links from the official Microsoft Research page:
- MSLR-WEB10K: https://1drv.ms/u/s!AtsMfWUz5l8nbOIoJ6Ks0bEMp78
- MSLR-WEB30K: https://1drv.ms/u/s!AtsMfWUz5l8nbXGPBlwD1rnFdBY

Source: https://www.microsoft.com/en-us/research/project/mslr/

## Changes
- Updated `_URLS` dictionary in `tensorflow_datasets/ranking/mslr_web/mslr_web.py`

## Testing
URLs verified to be accessible from the official Microsoft Research page.