### PR TITLE
Updated BeeDataset to not point to local NAS, instead use Github LSF

### DIFF
--- a/docs/catalog/bee_dataset.md
+++ b/docs/catalog/bee_dataset.md
@@ -3,10 +3,10 @@
     <meta itemprop="name" content="TensorFlow Datasets" />
   </div>
   <meta itemprop="name" content="bee_dataset" />
-  <meta itemprop="description" content="This dataset contains images and a set of labels that expose certain&#10;characterisitics of that images, such as *varroa-mite* infections, bees carrying&#10;*pollen-packets* or bee that are *cooling the hive* by flappingn their wings.&#10;Additionally, this dataset contains images of *wasps* to be able to distinguish&#10;bees and wasps.&#10;&#10;The images of the bees are taken from above and rotated. The bee is vertical and&#10;either its head or the trunk is on top. All images were taken with a green&#10;background and the distance to the bees was always the same, thus all bees have&#10;the same size.&#10;&#10;Each image can have multiple labels assigned to it. E.g. a bee can be cooling&#10;the hive and have a varrio-mite infection at the same time.&#10;&#10;This dataset is designed as mutli-label dataset, where each label, e.g.&#10;*varroa_output*, contains 1 if the characterisitic was present in the image and&#10;a 0 if it wasn&#x27;t. All images are provided by 300 pixel height and 150 pixel&#10;witdh. As default the dataset provides the images as 150x75 (h,w) pixel. You can&#10;select 300 pixel height by loading the datset with the name&#10;&quot;bee_dataset/bee_dataset_300&quot; and with 200 pixel height by&#10;&quot;bee_dataset/bee_dataset_200&quot;.&#10;&#10;License: GNU GENERAL PUBLIC LICENSE&#10;&#10;Author: Fabian Hickert &lt;Fabian.Hickert@raspbee.de&gt;&#10;&#10;To use this dataset:&#10;&#10;```python&#10;import tensorflow_datasets as tfds&#10;&#10;ds = tfds.load(&#x27;bee_dataset&#x27;, split=&#x27;train&#x27;)&#10;for ex in ds.take(4):&#10;  print(ex)&#10;```&#10;&#10;See [the guide](https://www.tensorflow.org/datasets/overview) for more&#10;informations on [tensorflow_datasets](https://www.tensorflow.org/datasets).&#10;&#10;&lt;img src=&quot;https://storage.googleapis.com/tfds-data/visualization/fig/bee_dataset-bee_dataset_300-1.0.0.png&quot; alt=&quot;Visualization&quot; width=&quot;500px&quot;&gt;&#10;&#10;" />
+  <meta itemprop="description" content="This dataset contains images and a set of labels that expose certain&#10;characterisitics of that images, such as *varroa-mite* infections, bees carrying&#10;*pollen-packets* or bee that are *cooling the hive* by flappingn their wings.&#10;Additionally, this dataset contains images of *wasps* to be able to distinguish&#10;bees and wasps.&#10;&#10;The images of the bees are taken from above and rotated. The bee is vertical and&#10;either its head or the trunk is on top. All images were taken with a green&#10;background and the distance to the bees was always the same, thus all bees have&#10;the same size.&#10;&#10;Each image can have multiple labels assigned to it. E.g. a bee can be cooling&#10;the hive and have a varrio-mite infection at the same time.&#10;&#10;This dataset is designed as mutli-label dataset, where each label, e.g.&#10;*varroa_output*, contains 1 if the characterisitic was present in the image and&#10;a 0 if it wasn&#x27;t. All images are provided by 300 pixel height and 150 pixel&#10;witdh. As default the dataset provides the images as 150x75 (h,w) pixel. You can&#10;select 300 pixel height by loading the datset with the name&#10;&quot;bee_dataset/bee_dataset_300&quot; and with 200 pixel height by&#10;&quot;bee_dataset/bee_dataset_200&quot;.&#10;&#10;License: GNU GENERAL PUBLIC LICENSE&#10;&#10;Author: Fabian Hickert &lt;Fabian.Hickert@posteo.de&gt;&#10;&#10;To use this dataset:&#10;&#10;```python&#10;import tensorflow_datasets as tfds&#10;&#10;ds = tfds.load(&#x27;bee_dataset&#x27;, split=&#x27;train&#x27;)&#10;for ex in ds.take(4):&#10;  print(ex)&#10;```&#10;&#10;See [the guide](https://www.tensorflow.org/datasets/overview) for more&#10;informations on [tensorflow_datasets](https://www.tensorflow.org/datasets).&#10;&#10;&lt;img src=&quot;https://storage.googleapis.com/tfds-data/visualization/fig/bee_dataset-bee_dataset_300-1.0.0.png&quot; alt=&quot;Visualization&quot; width=&quot;500px&quot;&gt;&#10;&#10;" />
   <meta itemprop="url" content="https://www.tensorflow.org/datasets/catalog/bee_dataset" />
-  <meta itemprop="sameAs" content="https://raspbee.de" />
-  <meta itemprop="citation" content="@misc{BeeAlarmed - A camera based bee-hive monitoring,&#10;  title =   &quot;Dataset for a camera based bee-hive monitoring&quot;,&#10;  url={https://github.com/BeeAlarmed}, journal={BeeAlarmed},&#10;  author =  &quot;Fabian Hickert&quot;,&#10;  year   =  &quot;2021&quot;,&#10;  NOTE   = &quot;\url{https://raspbee.de/} and \url{https://github.com/BeeAlarmed/BeeAlarmed}&quot;&#10;}" />
+  <meta itemprop="sameAs" content="https://github.com/BeeAlarmed/BeeDataset" />
+  <meta itemprop="citation" content="@misc{BeeAlarmed - A camera based bee-hive monitoring,&#10;  title =   &quot;Dataset for a camera based bee-hive monitoring&quot;,&#10;  url={https://github.com/BeeAlarmed}, journal={BeeAlarmed},&#10;  author =  &quot;Fabian Hickert&quot;,&#10;  year   =  &quot;2021&quot;,&#10;  NOTE   = &quot;\url{https://github.com/BeeAlarmed/BeeDataset}&quot;&#10;}" />
 </div>
 
 # `bee_dataset`
@@ -38,9 +38,9 @@ select 300 pixel height by loading the datset with the name
 
 License: GNU GENERAL PUBLIC LICENSE
 
-Author: Fabian Hickert <Fabian.Hickert@raspbee.de>
+Author: Fabian Hickert <Fabian.Hickert@posteo.de>
 
-*   **Homepage**: [https://raspbee.de](https://raspbee.de)
+*   **Homepage**: [https://github.com/BeeAlarmed/BeeDataset](https://github.com/BeeAlarmed/BeeDataset)
 
 *   **Source code**:
     [`tfds.datasets.bee_dataset.Builder`](https://github.com/tensorflow/datasets/tree/master/tensorflow_datasets/datasets/bee_dataset/bee_dataset_dataset_builder.py)
@@ -73,7 +73,7 @@ Split     | Examples
   url={https://github.com/BeeAlarmed}, journal={BeeAlarmed},
   author =  "Fabian Hickert",
   year   =  "2021",
-  NOTE   = "\url{https://raspbee.de/} and \url{https://github.com/BeeAlarmed/BeeAlarmed}"
+  NOTE   = "\url{https://github.com/BeeAlarmed/BeeDataset}"
 }
 ```
 

--- a/tensorflow_datasets/datasets/bee_dataset/CITATIONS.bib
+++ b/tensorflow_datasets/datasets/bee_dataset/CITATIONS.bib
@@ -3,5 +3,5 @@
   url={https://github.com/BeeAlarmed}, journal={BeeAlarmed},
   author =  "Fabian Hickert",
   year   =  "2021",
-  NOTE   = "\url{https://raspbee.de/} and \url{https://github.com/BeeAlarmed/BeeAlarmed}"
+  NOTE   = "\url{https://github.com/BeeAlarmed/BeeDataset} and \url{https://github.com/BeeAlarmed/BeeAlarmed}"
 }

--- a/tensorflow_datasets/datasets/bee_dataset/README.md
+++ b/tensorflow_datasets/datasets/bee_dataset/README.md
@@ -22,4 +22,4 @@ select 300 pixel height by loading the datset with the name
 
 License: GNU GENERAL PUBLIC LICENSE
 
-Author: Fabian Hickert <Fabian.Hickert@raspbee.de>
+Author: Fabian Hickert <Fabian.Hickert@posteo.de>

--- a/tensorflow_datasets/datasets/bee_dataset/bee_dataset_dataset_builder.py
+++ b/tensorflow_datasets/datasets/bee_dataset/bee_dataset_dataset_builder.py
@@ -43,7 +43,7 @@ class Builder(tfds.core.GeneratorBasedBuilder):
 
   VERSION = tfds.core.Version('1.0.0')
 
-  URL = 'https://raspbee.de/BeeDataset_20201121.zip'
+  URL = 'https://github.com/BeeAlarmed/BeeDataset/raw/refs/heads/main/BeeDataset_20201121.zip'
 
   BEE_CFG_300 = BeeDatasetConfig(
       name='bee_dataset_300',
@@ -63,7 +63,7 @@ class Builder(tfds.core.GeneratorBasedBuilder):
 
   BEE_CFG_150 = BeeDatasetConfig(
       name='bee_dataset_150',
-      description='BeeDataset images with 200 pixel height and 100 pixel width',
+      description='BeeDataset images with 150 pixel height and 75 pixel width',
       version='1.0.0',
       image_height=150,
       image_width=75,
@@ -79,8 +79,8 @@ class Builder(tfds.core.GeneratorBasedBuilder):
         self.builder_config.depth,
     )
     features = tfds.features.FeaturesDict({
-        'input': tfds.features.Image(shape=t_shape),
-        'output': {
+        'image': tfds.features.Image(shape=t_shape),
+        'label': {
             'varroa_output': np.float64,
             'pollen_output': np.float64,
             'wasps_output': np.float64,
@@ -90,8 +90,8 @@ class Builder(tfds.core.GeneratorBasedBuilder):
 
     return self.dataset_info_from_configs(
         features=features,
-        supervised_keys=('input', 'output'),
-        homepage='https://raspbee.de',
+        supervised_keys=('image', 'label'),
+        homepage='https://github.com/BeeAlarmed/BeeDataset',
     )
 
   def _split_generators(self, dl_manager):
@@ -116,8 +116,8 @@ class Builder(tfds.core.GeneratorBasedBuilder):
       img = path / f'images_{self.builder_config.height}' / name
 
       yield name + str(self.builder_config.height), {
-          'input': img,
-          'output': {
+          'image': img,
+          'label': {
               'varroa_output': labels[0],
               'pollen_output': labels[1],
               'wasps_output': labels[2],

--- a/tensorflow_datasets/datasets/bee_dataset/checksums.tsv
+++ b/tensorflow_datasets/datasets/bee_dataset/checksums.tsv
@@ -1,1 +1,1 @@
-https://raspbee.de/BeeDataset_20201121.zip	201735620	f219c7dc5d81712fb6f3423e2f5468e648260f2032720d87ebf14f218b5e3e43	BeeDataset_20201121.zip
+https://github.com/BeeAlarmed/BeeDataset/raw/refs/heads/main/BeeDataset_20201121.zip	201735620	f219c7dc5d81712fb6f3423e2f5468e648260f2032720d87ebf14f218b5e3e43	BeeDataset_20201121.zip

--- a/tensorflow_datasets/image_classification/bee_dataset/bee_dataset.py
+++ b/tensorflow_datasets/image_classification/bee_dataset/bee_dataset.py
@@ -14,12 +14,7 @@
 # limitations under the License.
 
 """Dataset definition for bee_dataset.
-
-DEPRECATED!
-If you want to use the BeeDataset dataset builder class, use:
-tfds.builder_cls('bee_dataset')
 """
 
-from tensorflow_datasets.core import lazy_builder_import
-
-BeeDataset = lazy_builder_import.LazyBuilderImport('bee_dataset')
+import tensorflow_datasets as tfds
+BeeDataset = tfds.builder_cls('bee_dataset')


### PR DESCRIPTION
Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# **UPDATED** Dataset

* Dataset Name: BeeDataset
* Issue Reference: --
* `dataset_info.json` Gist: <link>

## Description

Formerly the BeeDataset pointed to my local NAS to download the images, this caused problems, as it was often down. Moved the zip file to github LSF now. Also updated personal info such as Mail/Homepage.

## Checklist

* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [X] Run `download_and_prepare` successfully
* [X] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [X] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
