### PR TITLE
Fix: Replace deprecated pkg_resources with packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # PEP 508 specs
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "packaging"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ import itertools
 import os
 import sys
 
-import pkg_resources
+from packaging.version import Version
 import setuptools
 
 # To enable importing version.py directly, we add its path to sys.path.
@@ -40,7 +40,7 @@ from version import __version__  # pytype: disable=import-error  # pylint: disab
 if datestring := os.environ.get('TFDS_NIGHTLY_TIMESTAMP'):
   project_name = 'tfds-nightly'
   # Version as `X.Y.Z.dev199912312459`
-  curr_version = pkg_resources.parse_version(__version__)
+  curr_version = Version(__version__)
   __version__ = f'{curr_version.base_version}.dev{datestring}'
 else:
   project_name = 'tensorflow-datasets'


### PR DESCRIPTION
This commit fixes an issue where getting requirements to build wheel fails due to a `ModuleNotFoundError: No module named 'pkg_resources'`. The `pkg_resources` module is deprecated and has been removed from newer environments.

It replaces the usage of `pkg_resources.parse_version` with `packaging.version.Version` in `setup.py` and adds `"packaging"` to the `requires` array under `[build-system]` in `pyproject.toml`.

---
*PR created automatically by Jules for task [13593658195744190233](https://jules.google.com/task/13593658195744190233) started by @tomvdw*