### PR TITLE
Fix compatibility with Protobuf 5+ in `dataset_info.py`

### DIFF
--- a/tensorflow_datasets/core/dataset_info.py
+++ b/tensorflow_datasets/core/dataset_info.py
@@ -787,7 +787,7 @@ class DatasetInfo:
       # Otherwise, we restore the dataset_info.json value
       if field.type == field.TYPE_MESSAGE:
         field_value.MergeFrom(field_value_restored)
-      elif field.label == field.LABEL_REPEATED:
+      elif getattr(field, "is_repeated", getattr(field, "label", None) == getattr(field, "LABEL_REPEATED", 3)):
         del field_value[:]
         field_value.extend(field_value_restored)
       else:


### PR DESCRIPTION
Update dataset_info.py to check for `is_repeated` instead of `label` to support both older and newer versions of protobuf (5+).

---
*PR created automatically by Jules for task [2089587196834168595](https://jules.google.com/task/2089587196834168595) started by @tomvdw*