### PR TITLE
Fix TypeError in MultiplexedPath.joinpath calls

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -153,7 +153,10 @@ def _get_builder_datadir_path(builder_cls: Type[Any]) -> epath.Path:
   """
   pkg_names = builder_cls.__module__.split(".")
   # -1 to remove the xxx.py python file.
-  return epath.resource_path(pkg_names[0]).joinpath(*pkg_names[1:-1])
+  path = epath.resource_path(pkg_names[0])
+  for pkg_name in pkg_names[1:-1]:
+    path = path.joinpath(pkg_name)
+  return path
 
 
 class DatasetBuilder(registered.RegisteredDataset):
@@ -343,7 +346,9 @@ class DatasetBuilder(registered.RegisteredDataset):
             or path.parts
         ):
           modules[-1] += ".py"
-          return path.joinpath(*modules[1:])
+          for module in modules[1:]:
+            path = path.joinpath(module)
+          return path
     # Otherwise, fallback to `pathlib.Path`. For non-zipapp, it should be
     # equivalent to the above return.
     try:

--- a/tensorflow_datasets/core/utils/resource_utils.py
+++ b/tensorflow_datasets/core/utils/resource_utils.py
@@ -47,7 +47,10 @@ def tfds_path(*relative_path: epath.PathLike) -> epath.Path:
   Returns:
     path: The root TFDS path.
   """
-  return root_tfds_path().joinpath(*relative_path)
+  path = root_tfds_path()
+  for p in relative_path:
+    path = path.joinpath(p)
+  return path
 
 
 def tfds_write_path(*relative_path: epath.PathLike) -> epath.Path:


### PR DESCRIPTION
Fix TypeError in MultiplexedPath.joinpath calls

Change `path.joinpath(*multiple_args)` to iterative `.joinpath()` calls.
In newer Python versions, `epath.resource_path` returns an
`importlib.resources.readers.MultiplexedPath` whose `joinpath` method only
accepts a single positional argument in some execution environments (or via
certain compatibility patches). Unpacking multiple path components into it
results in a TypeError.

Iteratively calling `.joinpath` resolves the error and remains fully
compatible with standard `pathlib.Path` objects.

---
*PR created automatically by Jules for task [16329133361061968178](https://jules.google.com/task/16329133361061968178) started by @tomvdw*