### PR TITLE
fix(security): pin etils-actions/pypi-auto-publish and other Actions to commit SHAs

### DIFF
--- a/.github/workflows/pytest-optional.yml
+++ b/.github/workflows/pytest-optional.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - id: check
       uses: ./.github/actions/activate-tests
 

--- a/.github/workflows/pytest-template.yml
+++ b/.github/workflows/pytest-template.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ inputs.os-version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - uses: ./.github/actions/setup
       with:
         tf-version: ${{ inputs.tf-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - id: check
       uses: ./.github/actions/activate-tests
 
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - uses: ./.github/actions/setup
       with:
         tf-version: tensorflow
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - uses: ./.github/actions/setup
       with:
         tf-version: tensorflow
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - uses: ./.github/actions/setup
       with:
         tf-version: tensorflow

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo "TFDS_NIGHTLY_TIMESTAMP=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
 
     - name: Publish the package
-      uses: etils-actions/pypi-auto-publish@v1
+      uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.NIGHTLY_PYPI_PASSWORD }}
         parse-changelog: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ github.event.inputs.git-ref }}
 
@@ -35,7 +35,7 @@ jobs:
 
     # Publish the package (if local `__version__` > pip version)
     - name: Publish the package
-      uses: etils-actions/pypi-auto-publish@v1
+      uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_PASSWORD }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `release.yml` workflow uses **`etils-actions/pypi-auto-publish@v1`** — a mutable tag reference on a third-party action (only ~10 GitHub stars). If the `v1` tag is silently redirected (compromised maintainer, tag deletion + recreation), malicious code executes in the job holding **`PYPI_PASSWORD`**, enabling a supply-chain attack backdooring `tensorflow-datasets` on PyPI — a package with millions of downstream users.

Additional tag-pinned first-party actions (`actions/checkout@v3`, `actions/setup-python@v4`, `styfle/cancel-workflow-action@0.7.0`) in CI and release workflows also pinned to commit SHAs.

Follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).