### PR TITLE
Use fsspec as default backend in etils.epath to connect to GCS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,6 @@ REQUIRED_PKGS = [
     'dm-tree',
     'etils[edc,enp,epath,epy,etree]>=1.6.0;python_version<"3.11"',
     'etils[edc,enp,epath,epy,etree]>=1.9.1;python_version>="3.11"',
-    'fsspec',
-    'gcsfs',
     'immutabledict',
     'numpy',
     'promise',
@@ -227,6 +225,7 @@ HUGGINGFACE_ALL_DEPENDENCIES = [
 ] + ['datasets']
 
 EXTRAS = {
+    'gcs_prefer_fsspec': ['fsspec', 'gcsfs'],
     'matplotlib': ['matplotlib'],
     'tensorflow': ['tensorflow>=2.1'],
     'tf-nightly': ['tf-nightly'],

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ REQUIRED_PKGS = [
     'dm-tree',
     'etils[edc,enp,epath,epy,etree]>=1.6.0;python_version<"3.11"',
     'etils[edc,enp,epath,epy,etree]>=1.9.1;python_version>="3.11"',
+    'fsspec',
+    'gcsfs',
     'immutabledict',
     'numpy',
     'promise',

--- a/tensorflow_datasets/__init__.py
+++ b/tensorflow_datasets/__init__.py
@@ -39,6 +39,11 @@ tutorial](https://colab.research.google.com/github/tensorflow/datasets/blob/mast
 
 from __future__ import annotations
 
+import os
+
+if os.environ.get('GCS_PREFER_FSSPEC') == 'true':
+  os.environ['EPATH_PREFER_FSSPEC'] = 'true'
+
 from absl import logging
 from etils import epy as _epy
 

--- a/tensorflow_datasets/import_test.py
+++ b/tensorflow_datasets/import_test.py
@@ -15,6 +15,9 @@
 
 """Test import."""
 
+import os
+import subprocess
+import sys
 import tensorflow_datasets as tfds
 
 
@@ -22,6 +25,52 @@ class ImportTest(tfds.testing.TestCase):
 
   def test_import(self):
     pass
+
+  def test_gcs_prefer_fsspec_true(self):
+    env = os.environ.copy()
+    env['GCS_PREFER_FSSPEC'] = 'true'
+    env.pop('EPATH_PREFER_FSSPEC', None)
+
+    code = """
+import os
+import tensorflow_datasets as tfds
+from etils import epath
+print("EPATH_PREFER_FSSPEC:", os.environ.get('EPATH_PREFER_FSSPEC'))
+p = epath.Path('gs://dummy-bucket/file.txt')
+print("BACKEND:", type(p._backend).__name__)
+"""
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    self.assertIn("EPATH_PREFER_FSSPEC: true", result.stdout)
+    self.assertIn("BACKEND: _FileSystemSpecBackend", result.stdout)
+
+  def test_gcs_prefer_fsspec_false(self):
+    env = os.environ.copy()
+    env.pop('GCS_PREFER_FSSPEC', None)
+    env.pop('EPATH_PREFER_FSSPEC', None)
+
+    code = """
+import os
+import tensorflow_datasets as tfds
+from etils import epath
+print("EPATH_PREFER_FSSPEC:", os.environ.get('EPATH_PREFER_FSSPEC'))
+p = epath.Path('gs://dummy-bucket/file.txt')
+print("BACKEND:", type(p._backend).__name__)
+"""
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    self.assertIn("EPATH_PREFER_FSSPEC: None", result.stdout)
+    self.assertIn("BACKEND: _TfBackend", result.stdout)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Add Dataset / Backend Fix

* Dataset Name: mnist
* Issue Reference: 
* `dataset_info.json` Gist: <link to gist here if applicable>

## Description

This PR enables the use of `fsspec` and `gcsfs` as the backend for Google Cloud Storage (GCS) operations in `etils.epath` to support data loading from [GCS Rapid buckets](https://docs.cloud.google.com/storage/docs/rapid/rapid-bucket). 

With this change, if a user sets `GCS_PREFER_FSSPEC=true` in their environment, it will automatically set `EPATH_PREFER_FSSPEC=true` during initialization, switching the backend to `_FileSystemSpecBackend`. 

**Changes included:**
* **`tensorflow_datasets/__init__.py`**: Added environment variable check `if os.environ.get('GCS_PREFER_FSSPEC') == 'true':` to set `os.environ['EPATH_PREFER_FSSPEC'] = 'true'`.
* **`setup.py`**: Added `'gcs_prefer_fsspec': ['fsspec', 'gcsfs']` to `EXTRAS`.
* **`tensorflow_datasets/import_test.py`**: Added tests `test_gcs_prefer_fsspec_true` and `test_gcs_prefer_fsspec_false` to ensure the correct backend initializes.

**Validation:**
These changes were validated by successfully loading the `mnist` dataset stored in a Rapid bucket and Standard bucket. Data loading was successful after these changes were applied, confirming that the `fsspec` backend correctly handles reading from Rapid and existing standard storage class buckets.

## Checklist

* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [x] Run `download_and_prepare` successfully *(Note: verified via GCS bucket)*
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [x] Add passing test(s)
* [x] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
