### PR TITLE
Fix missing importlib_resources dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ REQUIRED_PKGS = [
     'tqdm',
     'wrapt',
     # Standard library backports
-    'importlib_resources;python_version<"3.9"',
+    'importlib_resources',
 ]
 
 TESTS_DEPENDENCIES = [


### PR DESCRIPTION
Fixes #11212.

`tensorflow_datasets` imports `importlib_resources` on Python 3.12+, but `setup.py` only declared the dependency for Python versions below 3.9. Declare the dependency for all supported Python versions so it is installed with TFDS.

Tests:
- `pytest -q tensorflow_datasets/core/dataset_builder_test.py`
- 54 passed, 17 skipped, 24 subtests passed in 12.49s